### PR TITLE
Pointed users to the documented DLMS Soap Call to add a device

### DIFF
--- a/Userguide/Addadevice.md
+++ b/Userguide/Addadevice.md
@@ -12,4 +12,4 @@ To add a DLMS Device to the Platform, take a look at the documentation of the So
 To add an OSLP Device to the Platform, the Soap call defined in [DeviceInstallation](https://github.com/OSGP/Platform/blob/development/osgp-adapter-ws-core/src/main/webapp/WEB-INF/wsdl/common/DeviceInstallation.wsdl) can be used.
 
 ### For each device additional actions may be required:
-Setting configuration, authorizations, schedules, firmware updates, etc. Please take a look at the WSDL files and the documentation for specific the specific Web Service calls.
+Please take a look at the [domain specific WSDL files](../Domains/README.md) in the documentation for more information on Web Service calls for Adding devices, Setting configuration, authorizations, schedules, firmware updates, etc.

--- a/Userguide/Addadevice.md
+++ b/Userguide/Addadevice.md
@@ -5,7 +5,11 @@ In order to add a device to the platform, call the add device method in the devi
 
 ### Implementation may differ for different device types
 Each device type may require its own set of attributes, security settings, etc.
-Each device type may have its own registration mechanism
+Each device type may have its own registration mechanism.
+
+To add a DLMS Device to the Platform, take a look at the documentation of the Soap call [AddDevice](../Domains/Smartmetering/smartmeteringwebservices/AddDevice.md) as defined in the [SmartMeteringInstallation.wsdl](https://github.com/OSGP/Platform/blob/development/osgp-adapter-ws-smartmetering/src/main/webapp/WEB-INF/wsdl/smartmetering/SmartMeteringInstallation.wsdl).
+
+To add an OSLP Device to the Platform, the Soap call defined in [DeviceInstallation](https://github.com/OSGP/Platform/blob/development/osgp-adapter-ws-core/src/main/webapp/WEB-INF/wsdl/common/DeviceInstallation.wsdl) can be used.
 
 ### For each device additional actions may be required:
-Setting configuration, authorizations, schedules, firmware updates, etc.
+Setting configuration, authorizations, schedules, firmware updates, etc. Please take a look at the WSDL files and the documentation for specific the specific Web Service calls.


### PR DESCRIPTION
Pointed users to the Soap call for adding a DLMS device.

For future reference, we should also create a page that describes the Generic AddDevice call as defined in common DeviceInstallation.wsdl.