### PR TITLE
OC-235 Fixed several minor language issues

### DIFF
--- a/Architecture/Architecture-Principles.md
+++ b/Architecture/Architecture-Principles.md
@@ -14,16 +14,16 @@ The use of layers improves the separation of responsibilities. Each application 
 - Presentation layer: responsible for providing information to users (persons and/or systems) and the handling of user requests
 - Application layer: responsible for executing system tasks including authorisation control
 - Domain layer: responsible for the representation of the problem domain.
-- Infrastructure: responsible for technical matters supporting other layers. For instance persistence, messaging, etc
+- Infrastructure layer: responsible for technical matters supporting other layers. For instance persistence, messaging, etc
 
 _Image, Layers:_
  ![alt text](./OSGP-components.png "Layers")
 
 1. Audit logger
-2. Webservices
+2. Web Services
 3. Functions
 4. Queue
-5. Worklow engine
+5. Workflow engine
 6. Protocol framework
 7. Protocol implementations
 8. Workflow engine
@@ -32,7 +32,7 @@ _Image, Layers:_
 
 ### Domain driven design (DDD)
 
-Domain-driven design focusses on the problem domain. DDD's starting point is creating an optimal model for a specific problem domain by having a common language and constructive collaboration between technical and domain experts.
+Domain-driven design focuses on the problem domain. DDD's starting point is creating an optimal model for a specific problem domain by having a common language and constructive collaboration between technical and domain experts.
 
 DDD uses the following building blocks:
 
@@ -45,14 +45,15 @@ DDD uses the following building blocks:
 
 ### Dependency inversion principle
 
-The dependency inversion principle promotes an independent connection by inverting dependency relations. This ensures that the domain model can be very 'clean' without knowledge of the underlying infrastructure (POJO classes). To apply this principle the Spring Framework is used.
+The dependency inversion principle promotes an independent connection by inverting dependency relations. This ensures that the domain model can be very 'clean' without knowledge of the underlying infrastructure (POJO classes). The Spring framework is used to implement the Dependency Inversion principle.
+
 
 ### Behavior driven development (BDD)
 
-Behavior driven development is a way of programming that first describes behavior in user stories and then implements this in the code. The user stories contain scenarios with acceptation criteria, which can be automated. This creates a complete test suite for the whole system.
+Behavior driven development is a way of programming that first describes behavior in user stories and then implements this in code. The user stories contain scenarios with acceptation criteria that can be automated. This creates a complete test suite for the whole system.
 
 For the application of BDD the following frameworks are used:
 
-- GivWenZen, extension for FitNesse to use Given When Then scenario's
 - FitNesse, acceptance testing framework, makes use of wiki.
-- Cucumber, automated acceptance testing, based on scenario's from stories.
+- GivWenZen, extension for FitNesse to use Given When Then scenario's
+- Cucumber, automated acceptance testing, based on scenarios from stories.

--- a/Architecture/Architecture-introduction.md
+++ b/Architecture/Architecture-introduction.md
@@ -8,13 +8,13 @@ Basic Overview
 
 ## Layered architecture
 
-The Open Smart Grid Platform environment consists of six layers:
+The Open Smart Grid Platform environment consists of five layers:
 
 1. Web services layer
 2. Domain logic layer
 3. Open Smart Grid Platform Core layer
 4. Protocol layer
-5. Devices
+5. Device layer
 
 ### Web services layer
 
@@ -22,11 +22,11 @@ In this layer the web services are exposed to the outside world. Applications ca
 
 ### Domain logic layer
 
-Every functional domain has a separate set of web services and a corresponding domain logic block. In the domain logic block the business logic of that functional domain can be found. This is where the translation of a functional named command will be translated into a generic intermediate format. In the case of public lighting the command "Turn light on" will be translated into a command like "set switch(1) in closed position". In this layer it could also be decided that one functional command results in multiple commands to a device. The domain logic is closely related to the webservices layers and can be added as well.
+Every functional domain has a separate set of web services and a corresponding domain logic block. In the domain logic block the business logic of that functional domain can be found. This is where a functional command will be translated into a generic intermediate format. For example, in the case of public lighting the command "Turn light on" will be translated into a command like "set switch(1) in closed position". In this layer it could also be decided that one functional command results in multiple commands to a device. The domain logic is closely related to the web services layers and can be added as well.
 
 ### Open Smart Grid Platform core layer
 
-In the core of the Open Smart Grid Platform the generic functions are found:
+In the core of the Open Smart Grid Platform the following generic functions are found:
 
 - Device management
 - Time synchronization
@@ -39,8 +39,8 @@ In the core of the Open Smart Grid Platform the generic functions are found:
 
 ### Protocol layer
 
-The different protocol adapters are found in this layer. Here the generic intermediate format of a command for a specific device will be translated into the protocol message the device understands. This message will be sent to the device. For communication failures there is a retry mechanism. The listeners for messages initiated by a device are implemented here. Examples are the DLMS/COSEM protocol adaptor for smart meters.
+The different protocol adapters are found in this layer. Here the generic intermediate format of a command for a specific device will be translated into the protocol message the device understands. This message will be sent to the device. A retry mechanism has been implemented to prevent communication failure in the case that the receiving end is temporarily unavailable. The listeners for messages initiated by a device are implemented here. Examples are the DLMS/COSEM protocol adapter for smart meters.
 
 ### Devices
 
-Any device in the public space with an internet connection may be connected to the platform. The platform is independent of the device used, therefore this part of the set-up is not part of the platform.
+Any device in the public space with an Internet connection may be connected to the platform. The platform is independent of the device used, therefore this part of the set-up is not part of the platform.

--- a/Architecture/Functionallayersoverview.md
+++ b/Architecture/Functionallayersoverview.md
@@ -7,7 +7,7 @@ _Image, functional layers overview_
 
 #### Starting architecture
 
-The Functional view shows an overview of the most important functions of the system. The two images below respectively show the starting architecture and functional reference architecture.
+The Functional view shows an overview of the most important functions of the system. The two images below show the starting architecture and functional reference architecture respectively.
 
 _Image, functional starting architecture_
  ![alt text](./functional-starting-architecture.png "Functional Starting Architecture")
@@ -24,7 +24,7 @@ _Image, functional starting architecture_
 
 ### Functional Reference
 
-This model partitions the system in 7 functional clusters (vertically) which are shown on the system layers (horizontally). The circled numbers refer to image 1.
+This model partitions the system in seven functional clusters (vertically) which are shown on the system layers (horizontally). The circled numbers refer to image 1.
 
 _Image, functional reference architecture_
 ![alt text](./functional-reference-architecture.png "Functional Reference Architecture")

--- a/Architecture/Logical-Authorisation-Model.md
+++ b/Architecture/Logical-Authorisation-Model.md
@@ -28,9 +28,9 @@ The functions an organisation can execute on a device are determined by the func
 
 This structure provides maximum flexibility when assigning rights to devices. Devices always belong to an Owner. An owner is an organisation, but not every organisation is an owner. The entity "Event", at the bottom of the image, is the execution of a function by an organisation on a device.
 
-Details like device-type, device-status etcetera have been omitted in this model.
+Details like device-type, device-status, etc. have been omitted from this model.
 
-One security requirement is that each event must be traced back to a 'natural'  person, also known as an audit trail. Although the open smart grid platform does not register individual users we can meet this requirement by registering a data-item with each event. This enables the user organisation to investigate which events belongs to which 'natural' person. This data-item can for example be an user-ID provided by the user-organisation which doesn't have to be unique in the open smart grid platform.
+One security requirement is that each event must be traced back to a 'natural' person, also known as an audit trail. Although the open smart grid platform does not register individual users we can meet this requirement by registering a data-item with each event. This enables the user organisation to investigate which events belongs to which 'natural' person. This data-item can for example be an user-ID provided by the user organisation which doesn't have to be unique in the open smart grid platform.
 
 Table describing the entities in the logical data-model
 
@@ -47,25 +47,25 @@ Table describing the entities in the logical data-model
 
 An organization can get rights to one or more function groups, and thus all functions in that function group will be available to this organization.
 
-To ensure that devices can only receive instructions from a 'genuine' open smart grid platform it must be possible to authenticate the open smart grid platform. This is implemented through a standard technology based on asymmetric encryption (If supported by the Device). The open smart grid platform will receive an unique key to enable the devices to tell if the messages come from a 'genuine' open smart grid platform. Both OSLP and DLMS device types use this kind of encryption. To prevent replay-attacks each message will get an index number (this is standard practice as well).
+To ensure that devices can only receive instructions from a 'genuine' open smart grid platform it must be possible to authenticate the open smart grid platform. This is implemented through a standard technology based on asymmetric encryption (if supported by the Device). The open smart grid platform will receive a unique key to enable the devices to tell if the messages come from a 'genuine' open smart grid platform. Both OSLP and DLMS device types use this kind of encryption. To prevent replay-attacks each message will get an index number (this is standard practice as well).
 
 #### Authentication of devices
 
-To make sure the open smart grid platform can distinguish between 'genuine' devices and 'illegal' devices all devices are supplied with a manufacturer key. Each device has an unique key. Because of the asymmetrical encryption the platform contains the public part of each key. In this way devices can be identified by their unique key and their unique hardware ID. The device-ID will be encrypted in each message sent from the device to the platform.
+To ensure that the open smart grid platform can distinguish between 'genuine' devices and 'illegal' devices, all devices are supplied with a manufacturer key. Each device has a unique key. Because of the asymmetrical encryption the platform contains the public part of each key. In this way devices can be identified by their unique key and their unique hardware ID. The device-ID will be encrypted in each message sent from the device to the platform.
 
 All communication between the open smart grid platform and the devices will be signed with these keys to ensure (1) the source is legitimate and (2) to ensure the integrity of the message. It is not necessary to encrypt the whole message because confidentiality is not important. This results in a less computationally intensive process.
 
-When a key is stolen (by hacking a device) this will not affect the integrity of the other devices. Each device has an unique key after all and only the hacked device has to be excluded from communicating in the platform.
+When a key is stolen (by hacking a device) this will not affect the integrity of the other devices. Each device has an unique key after all and only the hacked device has to be excluded from communication in the platform.
 
 The security is independent from the carrier (GPRS, CDMA, Ethernet, etc.). The open smart grid platform supports symmetric and asymmetric encryption (depends on device and protocol).
 
-For OSLP devices, the firmware will be used to distribute keys to devices. In this way we can use the existing secure firmware update mechanism for updating keys and certificates. DLMS devices use a mechanism to switch keys that is indepents of firmware updates.
+For OSLP devices, the firmware will be used to distribute keys to devices. In this way we can use the existing secure firmware update mechanism for updating keys and certificates. DLMS devices use a mechanism to switch keys that is not dependent on firmware updates.
 
 Additional security may be provided by using TLS communication.
 
 #### Authorisation of organisations
 
-Authorisation for use of the platform functionalities is handled by function groups. Function groups are defined for both platform functionality and device functionality. Each function group has one or more functions. Access to device functions can be set per device. The tables below respectively show an overview of all function-groups and device-functions and platform-groups and platform-functions.
+Authorisation for use of the platform functionalities is handled by function groups. Function groups are defined for both platform functionality and device functionality. Each function group has one or more functions. Access to device functions can be set per device. The tables below show an overview of all function-groups and device-functions and platform-groups and platform-functions respectively.
 
 |   | **Groups** |
 | --- | --- |

--- a/Architecture/Messageflow.md
+++ b/Architecture/Messageflow.md
@@ -1,5 +1,5 @@
 # Messageflow examples 
-This are some examples how an messages flows in the open smart grid platform.
+This are some examples how a message flows in the Open Smart Grid Platform.
 
 ## Message Flow:  Request/Acknowledge/Poll
 

--- a/Architecture/Models-and-views.md
+++ b/Architecture/Models-and-views.md
@@ -6,7 +6,7 @@ The image below shows a high-level view of the system's components.
 
 ![alt text](./design-view.png "Design View")
 
-### Data model an (not open source) smart lighting web application 
+### Data model of a (not open source) smart lighting web application 
 
 _Image showing the datamodel for the owners and management application_
 ![alt text](./data-model-web-application.png "Data Model Web Application")
@@ -28,7 +28,7 @@ Data model explanation:
 
 ### Logical view
 
-The logical view is a high-level overview of the system . The image below displays the main components and interfaces between these components.
+The logical view is a high-level overview of the system. The image below displays the main components and interfaces between these components.
 
  ![alt text](./logical-view.png "Logical View")
 

--- a/Architecture/Non-functional-overview.md
+++ b/Architecture/Non-functional-overview.md
@@ -1,6 +1,6 @@
 ## Non-functional view
 
-De non-functional view is an overview of the most significant non-functional demands.
+The non-functional view is an overview of the most significant non-functional demands.
 
 The identified non-functional demands are:
 

--- a/Architecture/OSGPProperties.md
+++ b/Architecture/OSGPProperties.md
@@ -1,6 +1,6 @@
 ## Properties of the Open Smart Grid Platform
 
-The open smart grid platform is designed for message based communication.
+The Open Smart Grid Platform is designed for message based communication.
 - Acts as a **connecting link** between (web)applications and smart devices
 - The open Source approach **prevents vendor lock-in** 
 - State of the art **security** 
@@ -9,26 +9,26 @@ The open smart grid platform is designed for message based communication.
 - Stimulates open innovation by using **open standards** and **open source** technology
 - **Multiple devices** and communication protocols are supported
 - **Independent** of (cloud) hosting infrastructure
-- By delinking the chain and the use of open standards and the open source license, everybody can build their applications on top of the open smart grid platform.
+- By de-linking the chain and the use of open standards and the open source license, anyone can build his or her applications on top of the open smart grid platform.
 - The open smart grid platform is **optimized** to provide reliable and efficient delivery of command and control information for e.g. [smart meters](http://en.wikipedia.org/wiki/Smart_meter), direct [load control](http://en.wikipedia.org/wiki/Load_control) modules, [solar panels](http://en.wikipedia.org/wiki/Solar_panels), gateways and other applications.
 - The open smart grid platform simplifies the implementation of smart devices resulting in a shorter time-to-market by having built-in **device management** features
 - The platform supports various IP data communication infrastructures to communicate with the devices (internet, lan, GPRS, CDMA, UMTS, etc.).
 - The open smart grid platform also supports authentication and encryption for all data exchanges to protect the integrity and privacy of data as required in e.g. the smart grid.
 - The open smart grid platform supports **multiple protocols**
 - **Easy application integration**
-- Supports **active-active** setup over multiple datacenters
+- Supports **active-active** setup over multiple data centers
 - Adding servers can be done in **runtime**
  
-Please note: the Open Smart Grid Platform is not build for streaming data such as video, audio or a stream of high frequency measurement data.
+Please note: the Open Smart Grid Platform is not built for streaming data such as video, audio or a stream of high frequency measurement data.
 
 ### Unique features of the Open Smart Grid Platform
 
-The Open Smart Grid Platform is unique by its multi-dimensional, generic and open design. Because of a true separation of layers and the use of open standards, other suppliers and/or third parties are able to develop and market innovative solutions.
+The Open Smart Grid Platform is unique due to its multi-dimensional, generic and open design. Because of a true separation of layers and the use of open standards, other suppliers and/or third parties are able to develop and market innovative solutions.
 
-1. The platform is **multidimensional**. This means that several customer use cases (with separate business models) are able to use the various device functions. One single application could use the same function of different devices. 
+1. The platform is **multi-dimensional**. This means that several customer use cases (with separate business models) are able to use the various device functions. One single application could use the same function of different devices. 
 2. The **generic** design ensures that the platform can be used in a flexible way for several functions and applications (e.g. public lighting services and smart meter services).
 3. The platform is aimed at the **'common parts'** of the technology chain; suppliers or vendors (of both applications and devices) have no competitive advantage in delivering these kind of services.
 4. The platform layers are truly separated by open standards and the platform is made available as **open source** software.
-5. The  platform does not hold on to any application data ( **stateless** ). No messages/commands will ever get lost.
+5. The platform does not store any application data (the platform is thus **stateless** ). No messages/commands will ever get lost.
 This enables third party vendors and developers to deliver innovative applications which are competitive in both rich functionalities and the generated data.
 

--- a/Architecture/Performance.md
+++ b/Architecture/Performance.md
@@ -6,8 +6,8 @@ The Platform was tested with the following AWS setup:
 
 Systems:
 
-- **Specs Component Server**: 2 CPU's, 8 GB Ram
-- **Specs DB Server**: 1 CPU, 2 GB Ram
+- **Specifications Component Server**: 2 CPU's, 8 GB RAM
+- **Specifications Database Server**: 1 CPU, 2 GB RAM
 
 Setup:
 
@@ -24,6 +24,3 @@ For the test to succeed, two requirements were to be met:
 2. Switch 40.000 simulated OSLP devices under 5 minutes.
 
 The results showed that both tests succeeded.
-
-
-

--- a/Architecture/Platform-components-description.md
+++ b/Architecture/Platform-components-description.md
@@ -1,5 +1,4 @@
-## Description of each of the platform components
-
+## Description of the individual platform components
 
 ### Application Layering
 
@@ -8,7 +7,7 @@ The use of layers improves the separation of responsibilities. Each application 
 - Presentation layer: responsible for providing information to users (persons and/or systems) and the handling of user requests
 - Application layer: responsible for executing system tasks including authorization control
 - Domain layer: responsible for the representation of the problem domain.
-- Infrastructure: responsible for technical matters supporting other layers. For instance persistence, messaging, etc
+- Infrastructure layer: responsible for technical matters supporting other layers. For instance persistence, messaging, etc
 
 **Layers:**
 
@@ -17,23 +16,23 @@ The use of layers improves the separation of responsibilities. Each application 
 
 ### Authentication and authorization
 
-The web server is configured with a SSL certificate to encrypt the incoming and outgoing communication. The SOAP Web service (Spring Framework web service) uses a Java Keystore and a certificate for each organization. Only organizations that are know within the platform and are authorized to use the web service.
+The web server is configured with a SSL certificate to encrypt the incoming and outgoing communication. The SOAP Web service (Spring Framework web service) uses a Java Keystore and a certificate for each organization. Only organizations that are known within the platform are authorized to use the web service.
 
 ### Application integration layer
 
 For the several functional domains separate SOAP Web services are offered. This separation offers authorization per functional domain. Each of the web service components send a queue message to the corresponding domain component.
 
 WSDL
-A separate WSDL is implemented for each functional cluster. All SOAP operations have a request object parameter and return a response object. For Synchronized Webservices  the result is immediately included in the response.
-For asynchronous web services the response contains a correlation ID. This Correlation ID  is to be used by the requester to receive the actual result from the platform. The following diagram is an example of such an asynchronous request.
+A separate WSDL is implemented for each functional cluster. All SOAP operations have a request object parameter and return a response object. For Synchronized Web Services the result is immediately included in the response.
+For asynchronous web services the response contains a correlation ID. This Correlation ID is to be used by the requester to receive the actual result from the platform. The following diagram is an example of such an asynchronous request.
 
 ![Web request example](./a-sync-web-service-request.png "A-Sync Web Service Request")
 
 Furthermore each SOAP message has a header which contains the user's organisation ID. This table displays an overview of the WSDL's including operations and fields in the request and response objects.
 
-SOAP vs REST
+SOAP vs. REST
 
-SOAP is chosen in the open smart grid platform webservices over REST for the following reasons:
+SOAP is chosen in the open smart grid platform web services over REST for the following reasons:
 - REST is resources/data oriented (put, get, delete) while the open smart grid platform is function/method oriented
 - SOAP has the advantage of having a contract (WSDL)
 - SOAP has extensive security features that are being used in the open smart grid platform to meet the high security demands/requirements requested by e.g. the energy utilities
@@ -53,7 +52,7 @@ More information on the specific domains can be found in the [domain chapter](..
 The open smart grid platform core component receives queue messages from domain components. These messages from domain components are forwarded to a protocol adapter project. The open smart grid platform core component also offers logic for a protocol adapter project to send the response of a smart device back to a domain project.
 The Core component routes messages from domain adapter components to protocol adapter components and vice versa. The core layer also contains a workflow engine.
 
-The internal databasemodel in the core layer:
+The internal database model in the core layer:
 ![alt text](./Core-datamodel/OSGP-core-model.png "Core model")
 ![alt text](./Core-datamodel/OSGP-core-logging-and-monitor-model.png "Logging and monitor model")
 ![alt text](./Core-datamodel/OSGP-core-OSLP-device-model.png "Device model")
@@ -73,8 +72,8 @@ Data model explanation:
 | oslp\_log\_item | Table for logging of OSLP messages. |
 | webservice monitor log item | Audit record for tracking webservice activity. |
 
-The platform will store as less data as possible
-Generic (and domain specific) devices attributes are stored in core DB
+The platform will store as little data as possible.
+Generic (and domain specific) devices attributes are stored in core DB.
 
 ### Protocol Layer
 
@@ -84,27 +83,26 @@ The open smart grid platform supports multiple protocols.
 - DLMS/COSEM
 - IEC61850
 
-The protocols can use of the of the security layers:
+The protocols can use one of the security layers:
 - TLS (Transport Layer Security encryption)
 - SSL (Secure Sockets Layer encryption)
 
-Other protocols can easily be added to the platform. Protocols based on open standards are prefered (if possible).
-A full list of current supported protocols can be found in the [protocols chapter](../Protocols/README.md).
+Other protocols can be easily added to the platform. If possible, we prefer protocols based on open standards.
+A comprehensive list of protocols that are currently supported can be found in the [protocols chapter](../Protocols/README.md).
 
-Protocol specific device attributes are stored in protocol adapter DB
+Protocol specific device attributes are stored in the protocol adapter DB
 
 ### Queues
-Queues are used to connect open smart grid platform components with each other.
+Open smart grid platform components connect to each other through message queues.
 
  ![Example how a queue works](./Queues.png "Queues")
 
 * Transactions on messages to and from the queues
-* Messages are persistence on the queues
+* Messages are persisted on the queues
 * Queues are clustered for reliability and speed
 * By using queues, the open smart grid platform can be stateless
 
-
 ### Smart devices
 
-The open smart grid platform can connect to any device as long as the device supports one of the supported protocols.
-Smart devices can receive messages from or send messages to protocol adapter components. In case of SSLD's this is done using TCP/IP over mobile internet connections (GPRS/CDMA). The communication is encrypted using public key cryptography.
+The open smart grid platform can connect to any device that supports one of the supported protocols.
+Smart devices can receive messages from or send messages to protocol adapter components. In case of SSLD's this is done using TCP/IP over mobile internet connections (e.g. GPRS, CDMA, etc.). The communication is encrypted using public key cryptography.

--- a/Architecture/README.md
+++ b/Architecture/README.md
@@ -1,3 +1,3 @@
 # CHAPTER 1 Technical overview of the Open Smart Grid Platform
 
-This chapter contains the general architecture and properties of the Open Smart Grid Platform. Domain and protocol specific information can be found in the domain and protocol chaptors. This chapter is written for (potential) users, architects and developers. 
+This chapter contains the general architecture and properties of the Open Smart Grid Platform. Domain and protocol specific information can be found in the domain and protocol chapters. This chapter is written for (potential) users, architects and developers. 

--- a/Architecture/Redundancy.md
+++ b/Architecture/Redundancy.md
@@ -1,15 +1,15 @@
 ### Redundancy
 
-This chapter describes the possibilities of a reduntant set up of the Open Smart Grid Platform. The Platform is designed to run in a HA-environment, and to prevent data loss due to unexpected failures. Each component of the Platform is designed to be stateless. Components communicate with each other using message queue's, which are processed in an asynchronious way.
+This chapter describes the possibilities of a redundant set up of the Open Smart Grid Platform. The Platform is designed to run in a High Available (or HA) environment, and to prevent data loss due to unexpected failures. Each component of the Platform is designed to be stateless. Components communicate with each other using message queues, which are processed in an asynchronous way.
 
 #### Active-active
-In an active-active setup, multiple instances of each component (eg. Web Services, Core, Protocol Adapter) process the data at the same time. Traffic is equally distrubuted across the instances. In case of a defect in one instance the traffic is automatically processed by the remaining instance(s).
+In an active-active setup, multiple instances of each component (eg. Web Services, Core, Protocol Adapter) process the data at the same time. Traffic is equally distributed across the instances. In case of a defect in one instance the traffic is automatically processed by the remaining instance(s).
 The Open Smart Grid Platform is designed to run in such a set up, and thus preventing down time in case of a failing server. Each component of the Platform can run in an independent, redundant and scalable way.
 
 #### Database
-The Open Smart Grid Platform uses a PostgreSQL database. PostgreSQL supports multiple database servers. For example, a slave and master node, where the slave node continuesly replicates the master node. In case the master node fails, the slave mode is triggered and will stop replicating from the master node, execute a recovery and will become the master node.
+The Open Smart Grid Platform uses a PostgreSQL database. PostgreSQL supports multiple database servers. For example, a slave and master node, where the slave node continuously replicates the master node. In case the master node fails, the slave mode is triggered and will stop replicating from the master node, execute a recovery and will become the master node.
 
 #### ActiveMQ
-The components of the Platform communicate with each other through a Message Queue. The Open Smart Grid Platform uses Apache Active Message Queue, which makes Asynchronious communication possible between the components. The components can register to the Queues as consumers. In case a consumer (eg. a server running a component of the platform) is down, the message will still be consumed by the remaining consumer(s). The Message Brokers can be used as a MasterSlave. In case the Master message broker is down, you get immediate failover to the slave with no message loss.
+The components of the Platform communicate with each other through a Message Queue. The Open Smart Grid Platform uses Apache Active Message Queue, which makes asynchronous communication possible between components. The components can register to the queues as consumers. In case a consumer (e.g. a server running a component of the platform) is down, the message will still be consumed by the remaining consumer(s). The Message Brokers can be used as a MasterSlave. In case the Master message broker is down, you get immediate fail-over to the slave without loss of messages.
 
 ![Redundancy Example](./redundancy.png "Redundancy")

--- a/Architecture/Scalability.md
+++ b/Architecture/Scalability.md
@@ -2,9 +2,9 @@
 
 The Open Smart Grid Platform is designed and built for scalability and reliability
 
-* Messages will never get lost, In the worst case scenario, a message will be send to the dead letter queue.
+* Messages will never get lost, In the worst case scenario, a message will be sent to the dead letter queue.
 * Any layer of the platform can be independently scaled up- and down
 * Adding servers can be done runtime
-* It can run in an active-active setup over multiple servers and datacenters. In our cloud hosted setup even over sets of datacenters in different countries.
+* It can run in an active-active setup over multiple servers and data centers. In our cloud hosted setup even over sets of data centers in different countries.
 
 ![Exmaple how the platform can scale](./OSGPscalability.png "Scalability")

--- a/Architecture/Technical-overview/CoreLayer.md
+++ b/Architecture/Technical-overview/CoreLayer.md
@@ -1,8 +1,8 @@
 ## Core Layer
 
-The Core layer of the Open Source Grid Platform is responsible for Validation, Tanslation, Authorisation and Routing of request messages. It also contains all the Domain Objects.
+The Core layer of the Open Source Grid Platform is responsible for Validation, Translation, Authorisation and Routing of request messages. It also contains all the Domain Objects.
 
-The core layer consists of two compoments:
+The core layer consists of two components:
 
 - osgp-domain-core: Shared Domain objects, services, repositories, etc. These classes are used through the entire platform.
 - osgp-core: Logic for routing domain requests, scheduling, retrying, etc.
@@ -10,12 +10,12 @@ The core layer consists of two compoments:
 ### General Package structure: osgp-domain-core
 
 - entities: Defines the entities used for persistence.
-- exceptions: Domain specific exceptions are residing here.
+- exceptions: Domain specific exceptions reside here.
 - repositories: Repositories that contain logic for persisting entities.
 - services: Domain services that reference a repository.
 - specifications: Interfaces that define specifications for Devices and Events.
 - validations: Validators and constraints.
-- valueobjects: Definitons of the Domain Objects.
+- valueobjects: Definitions of the Domain Objects.
 
 ### General Package structure: osgp-core
 
@@ -27,7 +27,7 @@ The core layer consists of two compoments:
 -- PersistenceConfig
 -- ProtocolMessagingConfig
 -- SchedulingConfig
-- services: Services that process device requests/responses. Checks for authorization, and if the request is supported by the platform. Then it routes the request to the right protocol adapter.
+- services: Services that process device requests/ responses. Checks for authorization, and if the request is supported by the platform, it will be routed to the appropriate protocol adapter.
 - tasks: Contains task scheduler logic.
 
 #### domain.model
@@ -38,5 +38,3 @@ These packages contain interfaces for the Services.
 #### infra.jms
 - domain: Contains Messages, MessageListeners and MessageProcessors for Domain related messaging.
 - protocol: Contains Messages, MessageListeners and MessageProcessors for Protocol related messaging.
-
-

--- a/Architecture/Technical-overview/DomainLayer.md
+++ b/Architecture/Technical-overview/DomainLayer.md
@@ -2,19 +2,19 @@
 
 The Domain Adapters are responsible for receiving requests from the Web Services layer, and delivering them to the Core layer. The Domain Layer mainly contains MessageProcessors and Services for request handling.
 
-The Core/Admin compoments contains the shared functionality, while the Domain components contain additonial domain specific funtionality.
+The Core/Admin components contains the shared functionality, while the Domain components contain additional domain specific functionality.
 
 At the moment the Platform uses the following Domain Adapters:
 
 Generic
-- Core - osgp-adapter-domain-core: Contains Core (common) functionality (AdHocManagement, FirmwareManagement, etc.)
-- Admin - osgp-adapter-domain-admin: Contains Admin functionality (DeviceManagement)
+- Core - osgp-adapter-domain-core: Contains Core (common) functionality;  AdHocManagement, FirmwareManagement, etc.
+- Admin - osgp-adapter-domain-admin: Contains Admin functionality, e.g. DeviceManagement.
 
 Domain
 - Public Lighting - osgp-adapter-domain-publiclighting: Contains functionality for the Public Lighting Domain.
 - Smart Metering - osgp-adapter-domain-smartmetering: Contains functionality for the Smart Metering Domain.
 - Tariff Switching - osgp-adapter-domain-tariffswitching: Contains functionality for the Tariff Switching Domain.
-- Microgrids - osgp-adapter-domain-microgrids: Contains functionality for the Microgrids domain.
+- Microgrids - osgp-adapter-domain-microgrids: Contains functionality for the Micro Grids domain.
 
 ### General Package structure
 

--- a/Architecture/Technical-overview/ProtocolLayer.md
+++ b/Architecture/Technical-overview/ProtocolLayer.md
@@ -1,11 +1,11 @@
 ## Protocol Adapters
 
-The Protocol Adapters are responsible for the actual communication to and from a device. They usually operate in a certain domain, and might use common/generic functions from the platform.
+The Protocol Adapters are responsible for the actual communication to and from a device. They usually operate in a certain domain, and might use common/ generic functions from the platform.
 
-The Open Smart Grid Platform currently has the following protcol adapters:
+The Open Smart Grid Platform currently has the following protocol adapters:
 - Protocol-Adapter-DLMS: Smart Metering
 - Protocol-Adapter-IEC61850: Public Lighting
-- Protocol-Adapter-OSLP: Public Lighting and Microgrids
+- Protocol-Adapter-OSLP: Public Lighting and Micro Grids
 
 ### General package structure
 
@@ -25,16 +25,16 @@ Contains the Protocol Adapter Objects used for the Protocol Adapter.
 - responses: Objects representing the responses that are supported by this adapter.
 
 #### domain
-- entities: Enities used for persistence.
+- entities: Entities used for persistence.
 - repositories: Repositories used for persistence.
 
 #### exceptions
-Contains the exceptions that might be thrown while communication with a device (For example, ValidationException, MessageRejectedException,etc)
+Contains the exceptions that might be thrown while communication with a device, e.g. ValidationException, MessageRejectedException, etc.
 
 #### infra
 This package contains all the code for communication through JMS (Platform) and Networking (Device).
 - messaging: Contains the JMS Messages, MessageListeners, MessageSenders and MessageProcessors.
-- networking: Contains the classes that are responsibel for connecting to a device using a certain protocol.
+- networking: Contains the classes that are responsible for connecting to a device using a certain protocol.
 
 #### services
 Services used to check the request status.

--- a/Architecture/Technical-overview/TechnicalOverview.md
+++ b/Architecture/Technical-overview/TechnicalOverview.md
@@ -1,15 +1,15 @@
 ## Technical Architecture
 
-This chapter gives an overview of a more technical nature. It describes each layer of the platform by giving an overview of it's packages and the code it contains. Furthermore it describes how a message is actually traveling through the platform. If you are planning on adding your own Domain Adapter or Protocol Adapter, it might be usefull to read through this chapter to get a feeling of how the Platform has been built.
+This chapter gives a more technical overview. It describes each layer of the platform by giving an overview of its packages and the code it contains. Furthermore it describes how a message proceeds through the platform. If you are planning on adding your own Domain Adapter or Protocol Adapter, it will be useful to read this chapter to get a feeling of how the Platform has been built.
 
 #### A Request through the Platform
 
-The picture below depicts an example of a request (OSLP SetLight request) traveling through the platform to a device.
+The picture below depicts an example of a request (OSLP SetLight request) proceeding through the platform to a device.
 ![alt text](./pictures/OsgpSetLightFlow.PNG)
 
-- A web request enters the platform at it's EndPoint, which in turns calls the RequestService. The RequestService checks if the organisation in the request is authorized, creates the request message and sends it to the MessageSender which in turn puts it on the queue of the Domain Adapter.
-- In the Domain Adapter, the incoming message is processed in the MessageProcessor, which in turn calls the Request Service. Here the message is converted to a Dto object. The CoreRequestMessageSender puts the message on the Core Queue.
-- The MessageListener in Core receives the message. The DeviceRequestMessageService contains generic functionality such as Authorization, Validation, etc. Once these procedures are completed, the message is routed to the right protocol adapter.
+- A web request enters the platform at its EndPoint, which in turns calls the RequestService. The RequestService checks if the organisation in the request is authorized, creates the request message and sends it to the MessageSender which in turn puts it on the queue of the Domain Adapter.
+- In the Domain Adapter, the incoming message is processed in the MessageProcessor, which in turn calls the Request Service. Here the message is converted to a DTO object. The CoreRequestMessageSender puts the message on the Core Queue.
+- The MessageListener in Core receives the message. The DeviceRequestMessageService contains generic functionality such as Authorization, Validation, etc. Once these procedures are completed, the message is routed to the appropriate protocol adapter.
 - In the Protocol Adapter the message is received by the MessageListener. It is processed through the MessageProcessor and OslpDeviceService. The request eventually ends up in the OslpChannelHandler, where the actual Protocol Request to the device is made.
 
 For a detailed description of each layer, please take a look at a more detailed description of each layer in this chapter.

--- a/Architecture/Technical-overview/Technologystack.md
+++ b/Architecture/Technical-overview/Technologystack.md
@@ -2,23 +2,23 @@
 
 ### Platform
 
-- [Apache ActiveMQ](http://activemq.apache.org/): Open source messaging server, used to relay messages between components of the open smart grid platform. ActiveMQ is an open source message broker written in Java together with a full Java Message Service (JMS) client. It provides "Enterprise Features" which in this case means fostering the communication from more than one client or server.
-- [Apache HTTP server](http://httpd.apache.org/): Webserver, used as front for Apache Tomcat.
-- [Apache Tomcat](http://tomcat.apache.org/): Provides a "pure Java" HTTP web server environment for Java code to run in.
+- [Apache ActiveMQ](http://activemq.apache.org/): Open source messaging server, used to relay messages between components of the open smart grid platform. ActiveMQ is an open source message broker written in Java and a full Java Message Service (JMS) client. It provides "Enterprise Features" which in this case means fostering the communication from more than one client or server.
+- [Apache HTTP server](http://httpd.apache.org/): Web server, used as front for Apache Tomcat.
+- [Apache Tomcat](http://tomcat.apache.org/): Provides a "pure Java" servlet container for Java code to run in.
 - [pgAdmin-III](http://www.pgadmin.org/): PostgreSQL administration and management tools.
 - [Protobuf (Google Protocol Buffers)](https://github.com/google/protobuf/): A language-neutral, platform-neutral, extensible way of serializing structured data for use in communications protocols, data storage, and more.
 - [Flyway](https://flywaydb.org/): Agile database migration framework for Java
 - [HikariCP](https://brettwooldridge.github.io/HikariCP/): JDBC connection pool
 - [Hibernate](http://hibernate.org/): Object/Relational mapping
 - [Netty](http://netty.io/): Network application framework for protocol servers & clients
-- [OpenMUC](https://www.openmuc.org/): Library implementing the IEC61850 and DLMS/COSEM communication  standard
+- [OpenMUC](https://www.openmuc.org/): Library implementing the IEC61850 and DLMS/COSEM communication standard
 - [Orika](http://orika-mapper.github.io/orika-docs/intro.html): Java bean mapping
-- [Spring](https://spring.io/): Application development framework. Various of its libraries are used, including Spring Data, Spring Security and Spring WS.
-- [Puppet](https://puppet.com/): Application for Automatically delivering, operating and securing your infrastructure 
+- [Spring](https://spring.io/): Application development framework. Several Spring libraries are used, including Spring Data, Spring Security and Spring WS.
+- [Puppet](https://puppet.com/): Application for Automatically delivering, operating and securing your infrastructure
 
 ### Development
 
-- [Bower](http://bower.io/): Package manager for Javascript packages. Web sites are made of lots of things - frameworks, libraries, assets, utilities, and rainbows. Bower manages all these things for you.
+- [Bower](http://bower.io/): Package manager for Javascript packages. Web applications consist of various components; frameworks, libraries, assets, utilities, and rainbows. Bower manages all these things for you.
 - [Eclipse](https://eclipse.org/): IDE for developing software.
 - [FileZilla](https://filezilla-project.org/): FTP application.
 - [Git](https://git-scm.com/): Version control system.
@@ -29,7 +29,6 @@
 - [Apache Maven](https://maven.apache.org/): Software project management tool
 - [GIT & GitHub](https://github.com/osgp): Source code management
 
-
 ### Testing &QA
 
 - [Apache JMeter](http://jmeter.apache.org/): Application designed to load test functional behaviour and measure performance.
@@ -37,11 +36,11 @@
 - [GivWenZen](https://github.com/weswilliams/GivWenZen): BDD extension for Fitnesse.
 - [Cucumber](https://cucumber.io/): automated acceptance testing framework.
 - [Sonarqube](http://www.sonarqube.org/): Quality management platform
-- [SoapUI](https://www.soapui.org/): Functional testing tool for API testing
-- [Mockito](http://mockito.org/): Unit testing
+- [SoapUI](https://www.soapui.org/): Functional testing tool for testing web services
 - [JUnit](http://junit.org/): Unit testing
+- [Mockito](http://mockito.org/): A Mock framework for Unit testing
 
-This Table presents an overview of the components and the most important technological choices per component.
+The following table presents an overview of the components and the most important technical choices per component.
 
 | **Component** | **Technology** |
 | --- | --- |

--- a/Architecture/Technical-overview/WebServicesLayer.md
+++ b/Architecture/Technical-overview/WebServicesLayer.md
@@ -1,20 +1,20 @@
 ## Web Services
 
-The Web Services layer contains the web services that are used to communicate with the Platform. The Open Source Smart Grid Platform uses the Simple Object Access Protocol (SOAP) to expose it's interfaces. The Web Services Adapter receives requests and sends those to the Domain Adapter. An incoming request is converted to a Domain Object, and put on the MessageQueue of the Domain layer. The Web Services layer also has a queue for incoming responses from the Domain adapter.
+The Web Services layer contains the web services that are used to communicate with the Platform. The Open Source Smart Grid Platform uses the Simple Object Access Protocol or SOAP to expose its interfaces. The Web Services Adapter receives requests and sends those to the Domain Adapter. An incoming request is converted to a Domain Object, and put on the MessageQueue of the Domain layer. The Web Services layer also has a queue for incoming responses from the Domain adapter.
 
-Each domain of the Platform has it's own web services:
+Each domain of the Platform has its own web services:
 
 #### Generic
-- Core - osgp-adapter-ws-core: Contains the Core(common) web services.
+- Core - osgp-adapter-ws-core: Contains the Core (common) web services.
 - Admin - osgp-adapter-ws-admin: Contains the Admin web services.
-- Shared - osgp-adapter-ws-shared: Contains shared endpoints (such as header authorization)
+- Shared - osgp-adapter-ws-shared: Contains shared endpoints, such as header authorization
 - Database - osgp-adapter-ws-db: Contains repositories for persistence.
 
 #### Domain
 - Public Lighting - osgp-adapter-ws-publiclighting: Contains the Public Lighting web services.
 - Smart Metering - osgp-adapter-ws-smartmetering: Contains the Smart Metering web services.
 - Tariff Swithcing - osgp-adapter-ws-tariffswitching: Contains the Tariff Switching web services.
-- Microgrids - osgp-adapter-ws-microgrids: Contains the Microgrids web services.
+- Microgrids - osgp-adapter-ws-microgrids: Contains the Micro Grids web services.
 
 For a description of the WSDL's see the [Domain Chapter](../../Domains/README.md).
 
@@ -30,10 +30,10 @@ A description of the general package structure of a web service component.
 -- WebServiceConfig
 - exceptionhandling: Exceptions are defined here.
 - mapping: Custom Orika converters.
-- services: Contains services this domain uses, such as AdHocManagement. These are called by the endpoints and basically convert the request to a Domain Object and put the request on the domain message queue using the JMS classes.
+- services: Contains services used by the domain, such as AdHocManagement. These are called by the end points and convert the request to a Domain Object and put the request on the domain message queue using the JMS classes.
 
 #### endpoints
-- EndPoints for the webServices: Contain a reference to a service, which handles the request further.
+- EndPoints for the web services: contain a reference to a service that proceeds with handling the request.
 
 #### infra
 - jms: contains the JMS classes such as:

--- a/Architecture/TimeBehavior.md
+++ b/Architecture/TimeBehavior.md
@@ -1,6 +1,6 @@
 ### Time Behavior
 
-Time behavior is mainly significant in the Flexovl application when a lot of devices have to be addressed in a short period of time over a wireless network. Both latency and limited bandwidth have to be taken in consideration while demanding the coordinated on and off switching of the lighting (We do not want the Christmas tree effect after all).
+Time behavior is mainly important in the Flexovl application when a lot of devices have to be addressed in a short period of time over a wireless network. Both latency and limited bandwidth have to be taken into consideration while demanding the coordinated on and off switching of the lighting, since we want to avoid the Christmas tree effect.
 
 - Time synchronization: devices periodically register with the platform and receive a time.
 - Protocol: because of the limited bandwidth an efficient protocol "protobuf" was selected.

--- a/Architecture/security.md
+++ b/Architecture/security.md
@@ -1,12 +1,12 @@
 ### Security
 
-The following security measures could in place for a hosted environment:
+The following security measures can be used in a hosted environment:
 ### Cloud security
 - DDOS protection
 - IPSEC VPN connections
 - IP whitelisting
 
-Most cloud envionments support these features.
+Most cloud environments support these features.
 
 ### Operating System 
 - Hardened operating systems (according to Center of Internet Security)
@@ -14,13 +14,13 @@ Most cloud envionments support these features.
 ### Platform security
 - Communication over TLS
 - Firewalls between all servers and layers
-- Certificates from a certificate authority
+- Certificates from a recognized Certificate Authority (CA)
 - Audit trail on all actions throughout the platform
 - Role based authorizations on specific functions of devices
 - Access control
 - Unique device identification
 
-For every major release there will be a mandated security test initiated by Smart society services.
+For every major release there will be a mandated security test initiated by Smart Society Services.
 
 In cooperation with the European Network of Cyber Security (ENCS) state of the art security measures were implemented.
 
@@ -46,11 +46,11 @@ In cooperation with the European Network of Cyber Security (ENCS) state of the a
 
 #### Encryption
 
-An analysis of safety aspects has led to the decision that the safety of the whole system will be realized by proven technology based on asymmetrical coding (Also known as public-key encryption).
+An analysis of safety aspects has led to the decision that the safety of the whole system will be realized by proven technology based on asymmetrical coding (also known as public-key encryption).
 
-#### Authentication of web-applications
+#### Authentication of web applications
 
-Two way SSL will be used between web-applications and the open smart grid platform to verify the identities for both parties. User organisations are responsible for the administration of the identity of and access to their web applications. The web applications feature a login page. After successful login the user is linked to an organisation. Passwords will be stored encrypted. The organisation ID will be sent in each message to the open smart grid platform and will be verified by the SSL certificate.
+Two-way SSL will be used between web applications and the Open Smart Grid Platform to verify the identities for both client and server. User organisations are responsible for the administration of the identity of and access to their web applications. The web applications feature a login page. After successful login the user is linked to an organisation. Passwords will be stored with encryption. The organisation ID will be sent in each message to the Open Smart Grid Platform and will be verified by the SSL certificate.
 
 #### Algorithms
 
@@ -67,5 +67,5 @@ A private APN is used for linking to mobile data communication infrastructures.
 
 
 ### Logging
-* Every action to and from devices is logged in the audittrail
+* Every action to and from devices is logged in the audit trail
 * Messages from unknown devices will be denied (and logged)

--- a/Domains/Admin/README.md
+++ b/Domains/Admin/README.md
@@ -1,7 +1,7 @@
 ## The open smart grid platform core and admin functions for device management.
 
 ## Scope
-This core and admin domain contains all generic webservices that can be used in other domains. Most generic services relate to device management including powerful device authorization management
+This core and admin domain contains all generic web services that can be used in other domains. Most generic services relate to device management including powerful device authorization management
 
 ### Common webservices
 

--- a/Domains/Smartlighting/README.md
+++ b/Domains/Smartlighting/README.md
@@ -4,7 +4,7 @@
 The goal of this domain is to control, monitor and manage (street) lights at scale. It allows streetlight owners to control/manage the (street) lights in an more intelligent way compared to ripple control technology.
 
 ## Features
-This domain consist of e.g. Switching schedules, groups, light sensors, manual switching and monitoring of a typical public lighting use-case.
+This domain consist of Switching schedules, groups, light sensors, manual switching and monitoring of a typical public lighting use-case.
 
 ##PublicLighting webservices
 

--- a/Domains/Smartlighting/Smartlightning-use-cases.md
+++ b/Domains/Smartlighting/Smartlightning-use-cases.md
@@ -20,20 +20,20 @@ FlexOVL, a new and flexible switching system of public lighting delivers more co
 
 **Implementation/roll-out**
 
-- Small scale roll-out started jan-2015
+- Small scale roll-out started January 2015
 - 200 Sub Stations will be fitted with an SSLD to control public lighting and tariff switching
 - 15 municipalities in the Liander grid operator area will be participating
 - Goal is to allow municipalities to use the application, give feedback and to see if the services offered to municipalities are adequate
 
 
 - Large scale roll-out will start around 2016
-- The entire Liander grid operator area will use SSLD's to controll all public lighting and tariff switching
+- The entire Liander grid operator area will use SSLD's to control all public lighting and tariff switching
 - About 25.000 Sub Stations (middenspanningsruimtes)
 - About 800.000 street lights will be switched by the SSLD's mounted in the 25.000 Sub Stations
 
 **FlexOVL web application (not open source available)**
 
-Municipalities are free to choose their own (web)application (using the webservices of the Open Smart Grid Platform), or they could use the default web application developed by Smart Society Services.
+Municipalities are free to choose their own (web)application (using the web services of the Open Smart Grid Platform), or they could use the default web application developed by Smart Society Services.
 
 ![alt text](./Smartscocietyservices-web-application.png "FlexOVL Web Application")
 

--- a/Domains/Smartmetering/README.md
+++ b/Domains/Smartmetering/README.md
@@ -1,19 +1,19 @@
 ## SmartMetering Documentation (Beta version)
 
-This chapter describes the SmartMetering domain including the webservices. Currently the webservices of the beta version are described, since the webservices have not yet officially been released.
+This chapter describes the SmartMetering domain including the web services. Currently the web services of the beta version are described, since the web services have not yet officially been released.
 Information on the DLMS device simulator can be found in the [DLMS protocol section](../Protocols/DLMS/Devicesimulator.md)
 
 ### Scope
-The goal of this domain is to read and manage millions of smart smart meters. This includes smart meter installation, firmware updates, smart meter removal, read smart meter values, time synchronisation, etc.
-Everything that is needed to professional manage millions of smart meters is or can be included in this domain.
+The goal of this domain is to read and manage millions of smart meters. This includes smart meter installation, firmware updates, smart meter removal, read smart meter values, time synchronisation, etc.
+Everything that is needed to professionally manage millions of smart meters is or can be included in this domain.
 
 ### Features
 
-Smart metering features available within on the open smart grid platform so far:
+Currently, the following Smart Metering features are available within the open smart grid platform:
 
 - Add smart meter to the platform, so the device is known and additional actions can be performed for the device
 - Process shipment file, which adds several smart meters to the platform along with all needed information
-- Synchronize time between smart meters and head-end system, in case the smart meter adjusts it's time, some events will be logged
+- Synchronize time between smart meters and head-end system, in case the smart meter adjusts its time, some events will be logged
 - Retrieve events from the smart meter, several event logs are available
 - Retrieve periodic meter reads from the smart meter
 
@@ -45,17 +45,17 @@ Smart metering features available within on the open smart grid platform so far:
 - **[GetSetPushSetupAlarmResponse](./smartmeteringwebservices/GetSetPushSetupAlarmResponse.md)** is a request which returns the response from the [SetPushSetupAlarm](./smartmeteringwebservices/SetPushSetupAlarm.md) request.
 - **[SetPushSetupSms](./smartmeteringwebservices/SetPushSetupSms.md)** is a request to set an endpoint in a device which tells the device where to connect to when it is waked up.
 - **[GetSetPushSetupSmsResponse](./smartmeteringwebservices/GetSetPushSetupSmsResponse.md)** is a request which returns the response from the [SetPushSetupSms](./smartmeteringwebservices/SetPushSetupSms.md) request.
-- **[SetAlarmNotifications](./smartmeteringwebservices/SetAlarmNotifications.md)** is a request to set the types of alarmnotifications that must be notified from the device when they occur.
+- **[SetAlarmNotifications](./smartmeteringwebservices/SetAlarmNotifications.md)** is a request to set the types of alarm notifications that must be notified from the device when they occur.
 - **[GetSetAlarmNotificationsResponse](./smartmeteringwebservices/GetSetAlarmNotificationsResponse.md)** is a request which returns the response from the [SetAlarmNotifications](./smartmeteringwebservices/SetAlarmNotifications.md) request.
 - **[SetEncryptionKeyExchangeOnGMeter](./smartmeteringwebservices/SetEncryptionKeyExchangeOnGMeter.md)** is a request to transfer and set a G-meter key on a device.
 - **[GetSetEncryptionKeyExchangeOnGMeterResponse](./smartmeteringwebservices/GetSetEncryptionKeyExchangeOnGMeterResponse.md)** is a request which returns the response from the [SetEncryptionKeyExchangeOnGMeter](./smartmeteringwebservices/SetEncryptionKeyExchangeOnGMeter.md) request.
-- **[SetActivityCalendar](./smartmeteringwebservices/SetActivityCalendar.md)** is a request to set several parameters on an E-meter such as tariffs per day in a weekprofile.
+- **[SetActivityCalendar](./smartmeteringwebservices/SetActivityCalendar.md)** is a request to set several parameters on an E-meter such as tariffs per day in a week profile.
 - **[GetSetActivityCalendarResponse](./smartmeteringwebservices/GetSetActivityCalendarResponse.md)** is a request which returns the response from the [SetActivityCalendar](./smartmeteringwebservices/SetActivityCalendar.md) request.
 - **[GetAdministrativeStatus](./smartmeteringwebservices/GetAdministrativeStatus.md)** is a request to retrieve the current AdministrativeStatus setting.
 - **[GetGetAdministrativeStatusResponse](./smartmeteringwebservices/GetGetAdministrativeStatusResponse.md)** is a request which returns the response from the [GetAdministrativeStatus](./smartmeteringwebservices/GetAdministrativeStatus.md) request.
 - **[SetAdministrativeStatus](./smartmeteringwebservices/SetAdministrativeStatus.md)** is a request to set the AdministrativeStatus.
 - **[GetSetAdministrativeStatusResponse](./smartmeteringwebservices/GetSetAdministrativeStatusResponse.md)** is a request which returns the response from the [SetAdministrativeStatus](./smartmeteringwebservices/SetAdministrativeStatus.md) request.
-- **[GetFirmwareVersion](./smartmeteringwebservices/GetFirmwareVersion.md)** is a request to retrieve the firmwareversion(s).
+- **[GetFirmwareVersion](./smartmeteringwebservices/GetFirmwareVersion.md)** is a request to retrieve the firmware version(s).
 - **[GetGetFirmwareVersionResponse](./smartmeteringwebservices/GetGetFirmwareVersionResponse.md)** is a request which returns the response from the [GetFirmwareVersionRequest](./smartmeteringwebservices/GetFirmwareVersion.md).
 - **[ReplaceKeys](./smartmeteringwebservices/ReplaceKeys.md)** is a request to change the keys on a E-meter.
 - **[GetReplaceKeysResponse](./smartmeteringwebservices/GetReplaceKeysResponse.md)** is a request which returns the response from the [ReplaceKeys](./smartmeteringwebservices/ReplaceKeys.md) request.

--- a/Domains/Smartmetering/smartmeteringwebservices/AddDevice.md
+++ b/Domains/Smartmetering/smartmeteringwebservices/AddDevice.md
@@ -19,7 +19,7 @@ AddDevice is a request to add a device to the OSGP database. The request needs t
 
 All requests have similar response behaviour which is described in [ResponseMessages](ResponseMessages.md)
 
-[GetAddDeviceResponse](GetAddDeviceResponse.md) returns if the result is successful from the  request. The response request contains the DeviceIdentification and CorrelationUid which is received from the AddDevice request.
+[GetAddDeviceResponse](GetAddDeviceResponse.md) returns if the result is successful from the request. The response contains the DeviceIdentification and CorrelationUid which is received from the AddDevice request.
 
 ### References
 

--- a/Domains/Smartmetering/smartmeteringwebservices/Bundle.md
+++ b/Domains/Smartmetering/smartmeteringwebservices/Bundle.md
@@ -1,9 +1,9 @@
 ## Bundle request
 
 ### Description
-Bundle is a special request in which one or more single request(s) to a specific device can be bundled. All request sent to this device make use of one communication channel, which may improve performance considerably.
+Bundle is a special request in which one or more single request(s) to a specific device can be bundled. All requests sent to this device make use of one communication channel, which may improve performance considerably.
 
-[GetBundleResponse](GetBundleResponse.md) returns the result of the actions of the bundle. The response request contains the DeviceIdentification and CorrelationUid which is received from the Bundle request.
+[GetBundleResponse](GetBundleResponse.md) returns the result of the actions of the bundle. The response contains the DeviceIdentification and CorrelationUid which is received from the Bundle request.
 
 The Bundle request has an **Actions** tag. This contains a list of one or more single request(s).
 The response behavior is described in [ResponseMessages](./ResponseMessages.md).

--- a/Domains/Smartmetering/smartmeteringwebservices/DeCoupleMbusDevice.md
+++ b/Domains/Smartmetering/smartmeteringwebservices/DeCoupleMbusDevice.md
@@ -7,7 +7,7 @@ DeCoupleMbusDevice is a request to decouple an Mbus device (such as a gas meter)
 
 All requests have similar response behaviour which is described in [ResponseMessages](ResponseMessages.md)
 
-[GetDeCoupleMbusDeviceResponse](GetDeCoupleMbusDeviceResponse.md) returns if the result is successful from the  request. The response request contains the DeviceIdentification and CorrelationUid which is received from the DeCoupleMbusDevice request.
+[GetDeCoupleMbusDeviceResponse](GetDeCoupleMbusDeviceResponse.md) returns if the result is successful from the request. The response contains the DeviceIdentification and CorrelationUid which is received from the DeCoupleMbusDevice request.
 
 ### References
 

--- a/Domains/Smartmetering/smartmeteringwebservices/DisableDebugging.md
+++ b/Domains/Smartmetering/smartmeteringwebservices/DisableDebugging.md
@@ -5,7 +5,7 @@ Disable debugging for a device. Communication with the device will be logged and
 
 All requests have similar response behaviour which is described in [ResponseMessages](./ResponseMessages.md).
 
-[GetDisableDebuggingResponse](./GetDisableDebuggingResponse.md) returns the result status. The response request contains the DeviceIdentification and CorrelationUid which is received from the SynchronizeTime request.
+[GetDisableDebuggingResponse](./GetDisableDebuggingResponse.md) returns the result status. The response contains the DeviceIdentification and CorrelationUid which is received from the GetDisableDebuggingRequest request.
 
 ### References
 

--- a/Domains/Smartmetering/smartmeteringwebservices/EnableDebugging.md
+++ b/Domains/Smartmetering/smartmeteringwebservices/EnableDebugging.md
@@ -5,7 +5,7 @@ Enable debugging for a device. Communication with the device will be logged and 
 
 All requests have similar response behaviour which is described in [ResponseMessages](./ResponseMessages.md).
 
-[GetEnableDebuggingResponse](./GetEnableDebuggingResponse.md) returns the result status. The response request contains the DeviceIdentification and CorrelationUid which is received from the SynchronizeTime request.
+[GetEnableDebuggingResponse](./GetEnableDebuggingResponse.md) returns the result status. The response contains the DeviceIdentification and CorrelationUid which is received from the GetEnableDebuggingRequest request.
 
 ### References
 

--- a/Domains/Smartmetering/smartmeteringwebservices/FindEvents.md
+++ b/Domains/Smartmetering/smartmeteringwebservices/FindEvents.md
@@ -13,7 +13,7 @@ DSMR Chapter 4.2.1 describes the several events and their description.
 
 All requests have similar response behaviour which is described in [ResponseMessages](./ResponseMessages.md).
 
-[GetFindEventsResponse](GetFindEventsResponse.md) returns if the result is successful from the  request. The response request contains the DeviceIdentification and CorrelationUid which is received from the FindEvents request.
+[GetFindEventsResponse](GetFindEventsResponse.md) returns if the result is successful from the request. The response contains the DeviceIdentification and CorrelationUid which is received from the FindEvents request.
 
 ### References
 

--- a/Domains/Smartmetering/smartmeteringwebservices/FindMessageLogs.md
+++ b/Domains/Smartmetering/smartmeteringwebservices/FindMessageLogs.md
@@ -6,10 +6,10 @@ The request needs the DeviceIdentification and a Page number to return.
 
 All requests have similar response behaviour which is described in [ResponseMessages](./ResponseMessages.md).
 
-[GetFindMessageLogsResponse](GetFindMessageLogsResponse.md) returns if the result is successful from the  request. The response request contains the DeviceIdentification and CorrelationUid which is received from the FindMessageLogs request.
+[GetFindMessageLogsResponse](GetFindMessageLogsResponse.md) returns if the result is successful from the  request. The response contains the DeviceIdentification and CorrelationUid which is received from the FindMessageLogs request.
 
 
-**Note: This functionality also exists in the admin devicemanagent service. It was duplicated here to be implemented asynchronously, as there is no support for asynchronous requests triggering a notification service in the admin project. As soon as asynchronous requests and notifications are implemented througout the OSGP platform, this method should be removed in favour of the admin implementation.**
+**Note: This functionality also exists in the admin device management service. It was duplicated here to be implemented asynchronously, as there is no support for asynchronous requests triggering a notification service in the admin project. As soon as asynchronous requests and notifications are implemented throughout the OSGP platform, this method should be removed in favour of the admin implementation.**
 
 
 ### References

--- a/Domains/Smartmetering/smartmeteringwebservices/GetActualMeterReads.md
+++ b/Domains/Smartmetering/smartmeteringwebservices/GetActualMeterReads.md
@@ -5,7 +5,7 @@ GetActualMeterReads is a request to retrieve the actual import and export meter 
 
 All requests have similar response behaviour which is described in [ResponseMessages](./ResponseMessages.md).
 
-[GetActualMeterReadsResponse](GetActualMeterReadsResponse.md) returns the retrieved meter reads values, unit and logtime from the GetActualMeterReads request. The response request contains the DeviceIdentification and CorrelationUid which is received from the GetActualMeterReads request.
+[GetActualMeterReadsResponse](GetActualMeterReadsResponse.md) returns the retrieved meter reads values, unit and log time from the GetActualMeterReads request. The response contains the DeviceIdentification and CorrelationUid which is received from the GetActualMeterReads request.
 
 ### References
 

--- a/Domains/Smartmetering/smartmeteringwebservices/GetActualMeterReadsGas.md
+++ b/Domains/Smartmetering/smartmeteringwebservices/GetActualMeterReadsGas.md
@@ -5,7 +5,7 @@ GetActualMeterReadsGas is a request to retrieve the actual import and export met
 
 All requests have similar response behaviour which is described in [ResponseMessages](./ResponseMessages.md).
 
-[GetActualMeterReadsGasResponse](GetActualMeterReadsGasResponse.md) returns the retrieved meter reads values, unit and logtime from the GetActualMeterReadsGas request. The response request contains the DeviceIdentification and CorrelationUid which is received from the GetActualMeterReadsGas request.
+[GetActualMeterReadsGasResponse](GetActualMeterReadsGasResponse.md) returns the retrieved meter reads values, unit and log time from the GetActualMeterReadsGas request. The response contains the DeviceIdentification and CorrelationUid which is received from the GetActualMeterReadsGas request.
 
 ### References
 

--- a/Domains/Smartmetering/smartmeteringwebservices/GetActualMeterReadsGasResponse.md
+++ b/Domains/Smartmetering/smartmeteringwebservices/GetActualMeterReadsGasResponse.md
@@ -1,7 +1,7 @@
 ## GetActualMeterReadsGasResponse request
 
 ### Description
-GetActualMeterReadsGasResponse returns the retrieved import and export values, unit and logtime from the ActualMeterReadsGas request. The response request contains the DeviceIdentification and CorrelationUid which is received from the [ActualMeterReadsGas](ActualMeterReadsGas.md) request.
+GetActualMeterReadsGasResponse returns the retrieved import and export values, unit and log time from the ActualMeterReadsGas request. The response contains the DeviceIdentification and CorrelationUid which is received from the [ActualMeterReadsGas](ActualMeterReadsGas.md) request.
 
 All requests have similar response behaviour which is described in [ResponseMessages](./ResponseMessages.md).
 

--- a/Domains/Smartmetering/smartmeteringwebservices/GetActualMeterReadsResponse.md
+++ b/Domains/Smartmetering/smartmeteringwebservices/GetActualMeterReadsResponse.md
@@ -1,7 +1,7 @@
 ## GetActualMeterReadsResponse request
 
 ### Description
-GetActualMeterReadsResponse returns the retrieved import and export values, unit and logtime from the ActualMeterReads request. The response request contains the DeviceIdentification and CorrelationUid which is received from the [GetActualMeterReads](GetActualMeterReads.md) request.
+GetActualMeterReadsResponse returns the retrieved import and export values, unit and logtime from the ActualMeterReads request. The response contains the DeviceIdentification and CorrelationUid which is received from the [GetActualMeterReads](GetActualMeterReads.md) request.
 
 All requests have similar response behaviour which is described in [ResponseMessages](./ResponseMessages.md).
 

--- a/Domains/Smartmetering/smartmeteringwebservices/GetAddDeviceResponse.md
+++ b/Domains/Smartmetering/smartmeteringwebservices/GetAddDeviceResponse.md
@@ -1,7 +1,7 @@
 ## GetAddDeviceResponse request
 
 ### Description
-GetAddDeviceResponse returns if the result is successful from the AddDevice request. The response request contains the DeviceIdentification and CorrelationUid which is received from the [AddDevice](AddDevice.md) request.
+GetAddDeviceResponse returns if the result is successful from the AddDevice request. The response contains the DeviceIdentification and CorrelationUid which is received from the [AddDevice](AddDevice.md) request.
 
 All requests have similar response behaviour which is described in [ResponseMessages](./ResponseMessages.md).
 

--- a/Domains/Smartmetering/smartmeteringwebservices/GetAdministrativeStatus.md
+++ b/Domains/Smartmetering/smartmeteringwebservices/GetAdministrativeStatus.md
@@ -5,7 +5,7 @@ GetAdministrativeStatus is a request to retrieve the current AdministrativeStatu
 
 All requests have similar response behaviour which is described in [ResponseMessages](./ResponseMessages.md).
 
-[GetGetAdministrativeStatusResponse](GetGetAdministrativeStatusResponse.md) returns if the setting GetAdministrativeStatus is enabled. The response request contains the DeviceIdentification and CorrelationUid which is received from the GetAdministrativeStatus request.
+[GetGetAdministrativeStatusResponse](GetGetAdministrativeStatusResponse.md) returns if the setting GetAdministrativeStatus is enabled. The response contains the DeviceIdentification and CorrelationUid which is received from the GetAdministrativeStatus request.
 
 ### References
 

--- a/Domains/Smartmetering/smartmeteringwebservices/GetAssociationLnObjects.md
+++ b/Domains/Smartmetering/smartmeteringwebservices/GetAssociationLnObjects.md
@@ -1,11 +1,11 @@
 ## GetAssociationLnObjects request
 
 ### Description
-GetAssociationLnObjects is a request to get the Association LN object tree from an E-meter. The request is send with the DeviceIdentification number from the desired device.
+GetAssociationLnObjects is a request to get the Association LN object tree from an E-meter. The request is sent with the DeviceIdentification number from the desired device.
 
 All requests have similar response behaviour which is described in [ResponseMessages](./ResponseMessages.md).
 
-[GetGetAssociationLnObjectsResponse](GetGetAssociationLnObjectsResponse.md) returns the result values from getting the Association LN object. The response request contains the DeviceIdentification and CorrelationUid which is received from the GetAssociationLnObjects request.
+[GetGetAssociationLnObjectsResponse](GetGetAssociationLnObjectsResponse.md) returns the result values from getting the Association LN object. The response contains the DeviceIdentification and CorrelationUid which is received from the GetAssociationLnObjects request.
 
 ### References
 

--- a/Domains/Smartmetering/smartmeteringwebservices/GetBundleResponse.md
+++ b/Domains/Smartmetering/smartmeteringwebservices/GetBundleResponse.md
@@ -1,7 +1,7 @@
 ## GetBundleResponse request
 
 ### Description
-GetBundleResponse returns the result of the bundle requested with the Bundle method. The response request contains the DeviceIdentification and CorrelationUid which is received from the [Bundle](Bundle.md) request.
+GetBundleResponse returns the result of the bundle requested with the Bundle method. The response contains the DeviceIdentification and CorrelationUid which is received from the [Bundle](Bundle.md) request.
 
 All requests have similar response behaviour which is described in [ResponseMessages](./ResponseMessages.md).
 

--- a/Domains/Smartmetering/smartmeteringwebservices/GetCoupleMbusDeviceResponse.md
+++ b/Domains/Smartmetering/smartmeteringwebservices/GetCoupleMbusDeviceResponse.md
@@ -1,7 +1,7 @@
 ## GetCoupleMbusDeviceResponse request
 
 ### Description
-GetCoupleMbusDeviceResponse returns if the result is successful from the CoupleMbusDevice request. The response request contains the DeviceIdentification and CorrelationUid which is received from the [CoupleMbusDevice](CoupleMbusDevice.md) request.
+GetCoupleMbusDeviceResponse returns if the result is successful from the CoupleMbusDevice request. The response contains the DeviceIdentification and CorrelationUid which is received from the [CoupleMbusDevice](CoupleMbusDevice.md) request.
 
 All requests have similar response behaviour which is described in [ResponseMessages](./ResponseMessages.md).
 

--- a/Domains/Smartmetering/smartmeteringwebservices/GetDeCoupleMbusDeviceResponse.md
+++ b/Domains/Smartmetering/smartmeteringwebservices/GetDeCoupleMbusDeviceResponse.md
@@ -1,7 +1,7 @@
 ## GetDeCoupleMbusDeviceResponse request
 
 ### Description
-GetDeCoupleMbusDeviceResponse returns if the result is successful from the DeCoupleMbusDevice request. The response request contains the DeviceIdentification and CorrelationUid which is received from the [DeCoupleMbusDevice](DeCoupleMbusDevice.md) request.
+GetDeCoupleMbusDeviceResponse returns if the result is successful from the DeCoupleMbusDevice request. The response contains the DeviceIdentification and CorrelationUid which is received from the [DeCoupleMbusDevice](DeCoupleMbusDevice.md) request.
 
 All requests have similar response behaviour which is described in [ResponseMessages](./ResponseMessages.md).
 

--- a/Domains/Smartmetering/smartmeteringwebservices/GetDisableDebuggingResponse.md
+++ b/Domains/Smartmetering/smartmeteringwebservices/GetDisableDebuggingResponse.md
@@ -1,7 +1,7 @@
 ## GetDisableDebuggingResponse request
 
 ### Description
-GetDisableDebuggingResponse returns the result from disabling debugging. The response request contains the DeviceIdentification and CorrelationUid which is received from the SynchronizeTime request.
+GetDisableDebuggingResponse returns the result from disabling debugging. The response contains the DeviceIdentification and CorrelationUid which is received from the SynchronizeTime request.
 
 All requests have similar response behaviour which is described in [ResponseMessages](./ResponseMessages.md).
 

--- a/Domains/Smartmetering/smartmeteringwebservices/GetEnableDebuggingResponse.md
+++ b/Domains/Smartmetering/smartmeteringwebservices/GetEnableDebuggingResponse.md
@@ -1,7 +1,7 @@
 ## GetEnableDebuggingResponse request
 
 ### Description
-GetEnableDebuggingResponse returns the result from enabling debugging. The response request contains the DeviceIdentification and CorrelationUid which is received from the SynchronizeTime request.
+GetEnableDebuggingResponse returns the result from enabling debugging. The response contains the DeviceIdentification and CorrelationUid which is received from the SynchronizeTime request.
 
 All requests have similar response behaviour which is described in [ResponseMessages](./ResponseMessages.md).
 

--- a/Domains/Smartmetering/smartmeteringwebservices/GetFindEventsResponse.md
+++ b/Domains/Smartmetering/smartmeteringwebservices/GetFindEventsResponse.md
@@ -1,7 +1,7 @@
 ## GetFindEventsResponse request
 
 ### Description
-GetFindEventsResponse returns if the result is successful from the FindEvents request. The response request contains the DeviceIdentification and CorrelationUid which is received from the [FindEvents](FindEvents.md) request.
+GetFindEventsResponse returns if the result is successful from the FindEvents request. The response contains the DeviceIdentification and CorrelationUid which is received from the [FindEvents](FindEvents.md) request.
 
 All requests have similar response behaviour which is described in [ResponseMessages](./ResponseMessages.md).
 

--- a/Domains/Smartmetering/smartmeteringwebservices/GetFindMessageLogsResponse.md
+++ b/Domains/Smartmetering/smartmeteringwebservices/GetFindMessageLogsResponse.md
@@ -1,7 +1,7 @@
 ## GetFindMessageLogsResponse request
 
 ### Description
-GetFindMessageLogsResponse returns if the result is successful from the FindMessageLogs request. The response request contains the DeviceIdentification and CorrelationUid which is received from the [FindMessageLogs](FindMessageLogs.md) request.
+GetFindMessageLogsResponse returns if the result is successful from the FindMessageLogs request. The response contains the DeviceIdentification and CorrelationUid which is received from the [FindMessageLogs](FindMessageLogs.md) request.
 
 All requests have similar response behaviour which is described in [ResponseMessages](./ResponseMessages.md).
 

--- a/Domains/Smartmetering/smartmeteringwebservices/GetFirmwareVersion.md
+++ b/Domains/Smartmetering/smartmeteringwebservices/GetFirmwareVersion.md
@@ -5,7 +5,7 @@ GetFirmwareVersion is a request to retrieve the firmware version(s) of a device.
 
 All requests have similar response behaviour which is described in [ResponseMessages](./ResponseMessages.md).
 
-[GetGetFirmwareVersionResponse](GetGetFirmwareVersionResponse.md) returns the version(s). The response request contains the DeviceIdentification and CorrelationUid which is received from the GetFirmwareVersion request.
+[GetGetFirmwareVersionResponse](GetGetFirmwareVersionResponse.md) returns the version(s). The response contains the DeviceIdentification and CorrelationUid which is received from the GetFirmwareVersion request.
 
 ### References
 

--- a/Domains/Smartmetering/smartmeteringwebservices/GetGetAdministrativeStatusResponse.md
+++ b/Domains/Smartmetering/smartmeteringwebservices/GetGetAdministrativeStatusResponse.md
@@ -1,7 +1,7 @@
 ## GetGetAdministrativeStatusResponse request
 
 ### Description
-GetGetAdministrativeStatusResponse returns if the setting GetAdministrativeStatus is enabled. The response request contains the DeviceIdentification and CorrelationUid which is received from the [GetAdministrativeStatus](GetAdministrativeStatus.md) request.
+GetGetAdministrativeStatusResponse returns if the setting GetAdministrativeStatus is enabled. The response contains the DeviceIdentification and CorrelationUid which is received from the [GetAdministrativeStatus](GetAdministrativeStatus.md) request.
 
 All requests have similar response behaviour which is described in [ResponseMessages](./ResponseMessages.md).
 

--- a/Domains/Smartmetering/smartmeteringwebservices/GetGetAssociationLnObjectsResponse.md
+++ b/Domains/Smartmetering/smartmeteringwebservices/GetGetAssociationLnObjectsResponse.md
@@ -1,7 +1,7 @@
 ## GetGetAssociationLnObjectsResponse request
 
 ### Description
-GetGetAssociationLnObjectsResponse returns the result values from getting the Association LN object. The response request contains the DeviceIdentification and CorrelationUid which is received from the [GetAssociationLnObjects](GetAssociationLnObjects.md) request.
+GetGetAssociationLnObjectsResponse returns the result values from getting the Association LN object. The response contains the DeviceIdentification and CorrelationUid which is received from the [GetAssociationLnObjects](GetAssociationLnObjects.md) request.
 
 All requests have similar response behaviour which is described in [ResponseMessages](./ResponseMessages.md).
 

--- a/Domains/Smartmetering/smartmeteringwebservices/GetGetFirmwareVersionResponse.md
+++ b/Domains/Smartmetering/smartmeteringwebservices/GetGetFirmwareVersionResponse.md
@@ -1,7 +1,7 @@
 ## GetGetFirmwareVersionResponse request
 
 ### Description
-GetGetFirmwareVersionResponse returns the device firmware versions requested with the GetFirmwareVersion method. The response request contains the DeviceIdentification and CorrelationUid which is received from the [GetFirmwareVersion](GetFirmwareVersion.md) request.
+GetGetFirmwareVersionResponse returns the device firmware versions requested with the GetFirmwareVersion method. The response contains the DeviceIdentification and CorrelationUid which is received from the [GetFirmwareVersion](GetFirmwareVersion.md) request.
 
 All requests have similar response behaviour which is described in [ResponseMessages](./ResponseMessages.md).
 

--- a/Domains/Smartmetering/smartmeteringwebservices/GetPeriodicMeterReads.md
+++ b/Domains/Smartmetering/smartmeteringwebservices/GetPeriodicMeterReads.md
@@ -5,7 +5,7 @@ GetPeriodicMeterReads is a request to retrieve the periodic import and export me
 
 All requests have similar response behaviour which is described in [ResponseMessages](./ResponseMessages.md).
 
-[GetPeriodicMeterReadsResponse](GetPeriodicMeterReadsResponse.md) returns the retrieved meter reads values, unit and logtime from the GetPeriodicMeterReads request. The response request contains the DeviceIdentification and CorrelationUid which is received from the GetPeriodicMeterReads request.
+[GetPeriodicMeterReadsResponse](GetPeriodicMeterReadsResponse.md) returns the retrieved meter reads values, unit and log time from the GetPeriodicMeterReads request. The response contains the DeviceIdentification and CorrelationUid which is received from the GetPeriodicMeterReads request.
 
 ### References
 

--- a/Domains/Smartmetering/smartmeteringwebservices/GetPeriodicMeterReadsGas.md
+++ b/Domains/Smartmetering/smartmeteringwebservices/GetPeriodicMeterReadsGas.md
@@ -1,11 +1,11 @@
 ## GetPeriodicMeterReadsGas request
 
 ### Description
-GetPeriodicMeterReadsGas is a request to retrieve the periodic import and export meter reads from a G-meter. The periode can be DAILY, MONTHLY or INTERVAL. The request needs the DeviceIdentification.
+GetPeriodicMeterReadsGas is a request to retrieve the periodic import and export meter reads from a G-meter. The period can be DAILY, MONTHLY or INTERVAL. The request needs the DeviceIdentification.
 
 All requests have similar response behaviour which is described in [ResponseMessages](./ResponseMessages.md).
 
-[GetPeriodicMeterReadsGasResponse](GetPeriodicMeterReadsGasResponse.md) returns the retrieved meter reads values, unit and logtime from the GetPeriodicMeterReadsGas request. The response request contains the DeviceIdentification and CorrelationUid which is received from the GetPeriodicMeterReadsGas request.
+[GetPeriodicMeterReadsGasResponse](GetPeriodicMeterReadsGasResponse.md) returns the retrieved meter reads values, unit and log time from the GetPeriodicMeterReadsGas request. The response contains the DeviceIdentification and CorrelationUid which is received from the GetPeriodicMeterReadsGas request.
 
 ### References
 

--- a/Domains/Smartmetering/smartmeteringwebservices/GetPeriodicMeterReadsGasResponse.md
+++ b/Domains/Smartmetering/smartmeteringwebservices/GetPeriodicMeterReadsGasResponse.md
@@ -1,7 +1,7 @@
 ## GetPeriodicMeterReadsGasResponse request
 
 ### Description
-GetPeriodicMeterReadsGasResponse returns the retrieved import and export values, unit and logtime from the PeriodicMeterReadsGas request. The response request contains the DeviceIdentification and CorrelationUid which is received from the [GetPeriodicMeterReadsGas](GetPeriodicMeterReadsGas.md) request.
+GetPeriodicMeterReadsGasResponse returns the retrieved import and export values, unit and log time from the PeriodicMeterReadsGas request. The response contains the DeviceIdentification and CorrelationUid which is received from the [GetPeriodicMeterReadsGas](GetPeriodicMeterReadsGas.md) request.
 
 All requests have similar response behaviour which is described in [ResponseMessages](./ResponseMessages.md).
 

--- a/Domains/Smartmetering/smartmeteringwebservices/GetPeriodicMeterReadsResponse.md
+++ b/Domains/Smartmetering/smartmeteringwebservices/GetPeriodicMeterReadsResponse.md
@@ -1,7 +1,7 @@
 ## GetPeriodicMeterReadsResponse request
 
 ### Description
-GetPeriodicMeterReadsResponse returns the retrieved import and export values, unit and logtime from the PeriodicMeterReads request. The response request contains the DeviceIdentification and CorrelationUid which is received from the [GetPeriodicMeterReads](GetPeriodicMeterReads.md) request.
+GetPeriodicMeterReadsResponse returns the retrieved import and export values, unit and log time from the PeriodicMeterReads request. The response contains the DeviceIdentification and CorrelationUid which is received from the [GetPeriodicMeterReads](GetPeriodicMeterReads.md) request.
 
 All requests have similar response behaviour which is described in [ResponseMessages](./ResponseMessages.md).
 

--- a/Domains/Smartmetering/smartmeteringwebservices/GetReadAlarmRegisterResponse.md
+++ b/Domains/Smartmetering/smartmeteringwebservices/GetReadAlarmRegisterResponse.md
@@ -1,7 +1,7 @@
 ## GetReadAlarmRegisterResponse request
 
 ### Description
-GetReadAlarmRegisterResponse returns the alarm notifications from the ReadAlarmRegister request. The response request contains the DeviceIdentification and CorrelationUid which is received from the [ReadAlarmRegister](ReadAlarmRegister.md) request.
+GetReadAlarmRegisterResponse returns the alarm notifications from the ReadAlarmRegister request. The response contains the DeviceIdentification and CorrelationUid which is received from the [ReadAlarmRegister](ReadAlarmRegister.md) request.
 
 All requests have similar response behaviour which is described in [ResponseMessages](./ResponseMessages.md).
 

--- a/Domains/Smartmetering/smartmeteringwebservices/GetReplaceKeysResponse.md
+++ b/Domains/Smartmetering/smartmeteringwebservices/GetReplaceKeysResponse.md
@@ -1,7 +1,7 @@
 ## GetReplaceKeysResponse request
 
 ### Description
-GetReplaceKeysResponse returns if the result is successful from the ReplaceKeys request. The response request contains the DeviceIdentification and CorrelationUid which is received from the [ReplaceKeys](ReplaceKeys.md) request.
+GetReplaceKeysResponse returns if the result is successful from the ReplaceKeys request. The response contains the DeviceIdentification and CorrelationUid which is received from the [ReplaceKeys](ReplaceKeys.md) request.
 
 All requests have similar response behaviour which is described in [ResponseMessages](./ResponseMessages.md).
 

--- a/Domains/Smartmetering/smartmeteringwebservices/GetRetrieveAllAttributeValuesResponse.md
+++ b/Domains/Smartmetering/smartmeteringwebservices/GetRetrieveAllAttributeValuesResponse.md
@@ -1,7 +1,7 @@
 ## GetRetrieveAllAttributeValuesResponse request
 
 ### Description
-GetRetrieveAllAttributeValuesResponse returns the result values from getting all the attribute values of all the objects in the device. The response request contains the DeviceIdentification and CorrelationUid which is received from the [RetrieveAllAttributeValues](RetrieveAllAttributeValues.md) request.
+GetRetrieveAllAttributeValuesResponse returns the result values from getting all the attribute values of all the objects in the device. The response contains the DeviceIdentification and CorrelationUid which is received from the [RetrieveAllAttributeValues](RetrieveAllAttributeValues.md) request.
 
 All requests have similar response behaviour which is described in [ResponseMessages](./ResponseMessages.md).
 

--- a/Domains/Smartmetering/smartmeteringwebservices/GetSetActivityCalendarResponse.md
+++ b/Domains/Smartmetering/smartmeteringwebservices/GetSetActivityCalendarResponse.md
@@ -1,7 +1,7 @@
 ## GetSetActivityCalendarResponse request
 
 ### Description
-GetSetActivityCalendarResponse returns the result from setting a SetActivityCalendar. The response request contains the DeviceIdentification and CorrelationUid which is received from the [SetActivityCalendar](SetActivityCalendar.md) request.
+GetSetActivityCalendarResponse returns the result from setting a SetActivityCalendar. The response contains the DeviceIdentification and CorrelationUid which is received from the [SetActivityCalendar](SetActivityCalendar.md) request.
 
 All requests have similar response behaviour which is described in [ResponseMessages](./ResponseMessages.md).
 

--- a/Domains/Smartmetering/smartmeteringwebservices/GetSetAdministrativeStatusResponse.md
+++ b/Domains/Smartmetering/smartmeteringwebservices/GetSetAdministrativeStatusResponse.md
@@ -1,7 +1,7 @@
 ## GetSetAdministrativeStatusResponse request
 
 ### Description
-GetSetAdministrativeStatusResponse returns if the setting SetAdministrativeStatus is enabled. The response request contains the DeviceIdentification and CorrelationUid which is received from the [SetAdministrativeStatus](SetAdministrativeStatus.md) request.
+GetSetAdministrativeStatusResponse returns if the setting SetAdministrativeStatus is enabled. The response contains the DeviceIdentification and CorrelationUid which is received from the [SetAdministrativeStatus](SetAdministrativeStatus.md) request.
 
 All requests have similar response behaviour which is described in [ResponseMessages](./ResponseMessages.md).
 

--- a/Domains/Smartmetering/smartmeteringwebservices/GetSetAlarmNotificationsResponse.md
+++ b/Domains/Smartmetering/smartmeteringwebservices/GetSetAlarmNotificationsResponse.md
@@ -1,7 +1,7 @@
 ## GetSetAlarmNotificationsResponse request
 
 ### Description
-GetSetAlarmNotificationsResponse returns the result from setting a SetAlarmNotifications. The response request contains the DeviceIdentification and CorrelationUid which is received from the [SetAlarmNotifications](SetAlarmNotifications.md) request.
+GetSetAlarmNotificationsResponse returns the result from setting a SetAlarmNotifications. The response contains the DeviceIdentification and CorrelationUid which is received from the [SetAlarmNotifications](SetAlarmNotifications.md) request.
 
 All requests have similar response behaviour which is described in [ResponseMessages](./ResponseMessages.md).
 

--- a/Domains/Smartmetering/smartmeteringwebservices/GetSetConfigurationObjectResponse.md
+++ b/Domains/Smartmetering/smartmeteringwebservices/GetSetConfigurationObjectResponse.md
@@ -1,7 +1,7 @@
 ## GetSetConfigurationObjectResponse request
 
 ### Description
-GetSetConfigurationObjectResponse returns the result from setting a ConfigurationObject. The response request contains the DeviceIdentification and CorrelationUid which is received from the [SetConfigurationObject](SetConfigurationObject.md) request.
+GetSetConfigurationObjectResponse returns the result from setting a ConfigurationObject. The response contains the DeviceIdentification and CorrelationUid which is received from the [SetConfigurationObject](SetConfigurationObject.md) request.
 
 All requests have similar response behaviour which is described in [ResponseMessages](./ResponseMessages.md).
 

--- a/Domains/Smartmetering/smartmeteringwebservices/GetSetEncryptionKeyExchangeOnGMeterResponse.md
+++ b/Domains/Smartmetering/smartmeteringwebservices/GetSetEncryptionKeyExchangeOnGMeterResponse.md
@@ -1,7 +1,7 @@
 ## GetSetEncryptionKeyExchangeOnGMeterResponse request
 
 ### Description
-GetSetEncryptionKeyExchangeOnGMeterResponse returns the result from setting a SetEncryptionKeyExchangeOnGMeter. The response request contains the DeviceIdentification and CorrelationUid which is received from the [SetEncryptionKeyExchangeOnGMeter](SetEncryptionKeyExchangeOnGMeter.md) request.
+GetSetEncryptionKeyExchangeOnGMeterResponse returns the result from setting a SetEncryptionKeyExchangeOnGMeter. The response contains the DeviceIdentification and CorrelationUid which is received from the [SetEncryptionKeyExchangeOnGMeter](SetEncryptionKeyExchangeOnGMeter.md) request.
 
 All requests have similar response behaviour which is described in [ResponseMessages](./ResponseMessages.md).
 

--- a/Domains/Smartmetering/smartmeteringwebservices/GetSetPushSetupAlarmResponse.md
+++ b/Domains/Smartmetering/smartmeteringwebservices/GetSetPushSetupAlarmResponse.md
@@ -1,7 +1,7 @@
 ## GetSetPushSetupAlarmResponse
 
 ### Description
-GetSetPushSetupAlarmResponse returns the result from setting a SetPushSetupAlarm. The response request contains the DeviceIdentification and CorrelationUid which is received from the [SetPushSetupAlarm](SetPushSetupAlarm.md) request.
+GetSetPushSetupAlarmResponse returns the result from setting a SetPushSetupAlarm. The response contains the DeviceIdentification and CorrelationUid which is received from the [SetPushSetupAlarm](SetPushSetupAlarm.md) request.
 
 All requests have similar response behaviour which is described in [ResponseMessages](./ResponseMessages.md).
 

--- a/Domains/Smartmetering/smartmeteringwebservices/GetSetPushSetupSmsResponse.md
+++ b/Domains/Smartmetering/smartmeteringwebservices/GetSetPushSetupSmsResponse.md
@@ -1,7 +1,7 @@
 ## GetSetPushSetupSmsResponse request
 
 ### Description
-GetSetPushSetupSmsResponse returns the result from setting a SetPushSetupSms. The response request contains the DeviceIdentification and CorrelationUid which is received from the [SetPushSetupSms](SetPushSetupSms.md) request.
+GetSetPushSetupSmsResponse returns the result from setting a SetPushSetupSms. The response contains the DeviceIdentification and CorrelationUid which is received from the [SetPushSetupSms](SetPushSetupSms.md) request.
 
 All requests have similar response behaviour which is described in [ResponseMessages](./ResponseMessages.md).
 

--- a/Domains/Smartmetering/smartmeteringwebservices/GetSetSpecialDaysResponse.md
+++ b/Domains/Smartmetering/smartmeteringwebservices/GetSetSpecialDaysResponse.md
@@ -1,7 +1,7 @@
 ## GetSetSpecialDaysResponse request
 
 ### Description
-GetSetSpecialDaysResponse returns the result from setting a Special Day. The response request contains the DeviceIdentification and CorrelationUid which is received from the [SetSpecialDays](SetSpecialDays.md) request.
+GetSetSpecialDaysResponse returns the result from setting a Special Day. The response contains the DeviceIdentification and CorrelationUid which is received from the [SetSpecialDays](SetSpecialDays.md) request.
 
 All requests have similar response behaviour which is described in [ResponseMessages](./ResponseMessages.md).
 

--- a/Domains/Smartmetering/smartmeteringwebservices/GetSpecificAttributeValue.md
+++ b/Domains/Smartmetering/smartmeteringwebservices/GetSpecificAttributeValue.md
@@ -3,12 +3,14 @@
 ### Description
 GetSpecificAttributeValue is a request to get a specific attribute value from an ObisCode from an E-meter.
 
-The request is send with the DeviceIdentification number from the desired device and
-dlms specific values that point to the object: a ClassId, an ObisCode and an AttributeId
+The request is sent with the DeviceIdentification number from the desired device and dlms specific values that point to the object: 
+- a ClassId
+- an ObisCode 
+- and an AttributeId
 
 All requests have similar response behaviour which is described in [ResponseMessages](./ResponseMessages.md).
 
-[GetSpecificAttributeValueResponse](GetSpecificAttributeValueResponse.md) returns the result values as text (String) from getting the configuration object. The response request contains the DeviceIdentification and CorrelationUid which is received from the GetSpecificAttributeValue request.
+[GetSpecificAttributeValueResponse](GetSpecificAttributeValueResponse.md) returns the result values as text (String) from getting the configuration object. The response contains the DeviceIdentification and CorrelationUid which is received from the GetSpecificAttributeValue request.
 
 ### References
 

--- a/Domains/Smartmetering/smartmeteringwebservices/GetSpecificAttributeValueResponse.md
+++ b/Domains/Smartmetering/smartmeteringwebservices/GetSpecificAttributeValueResponse.md
@@ -1,7 +1,7 @@
 ## GetSpecificAttributeValueResponse request
 
 ### Description
-GetSpecificAttributeValueResponse returns the result values as text from getting the configuration objects. The response request contains the DeviceIdentification and CorrelationUid which is received from the [GetSpecificAttributeValue](GetSpecificAttributeValue.md) request.
+GetSpecificAttributeValueResponse returns the result values as text from getting the configuration objects. The response contains the DeviceIdentification and CorrelationUid which is received from the [GetSpecificAttributeValue](GetSpecificAttributeValue.md) request.
 
 All requests have similar response behaviour which is described in [ResponseMessages](./ResponseMessages.md).
 

--- a/Domains/Smartmetering/smartmeteringwebservices/GetSynchronizeTimeResponse.md
+++ b/Domains/Smartmetering/smartmeteringwebservices/GetSynchronizeTimeResponse.md
@@ -1,7 +1,7 @@
 ## GetSynchronizeTimeResponse request
 
 ### Description
-GetSynchronizeTimeResponse returns the result from synchronizing date and time. The response request contains the DeviceIdentification and CorrelationUid which is received from the SynchronizeTime request.
+GetSynchronizeTimeResponse returns the result from synchronizing date and time. The response contains the DeviceIdentification and CorrelationUid which is received from the SynchronizeTime request.
 
 All requests have similar response behaviour which is described in [ResponseMessages](./ResponseMessages.md).
 

--- a/Domains/Smartmetering/smartmeteringwebservices/GetUpdateFirmwareResponse.md
+++ b/Domains/Smartmetering/smartmeteringwebservices/GetUpdateFirmwareResponse.md
@@ -1,7 +1,7 @@
 ## GetUpdateFirmwareResponse request
 
 ### Description
-GetUpdateFirmwareResponse returns the device firmware versions that are on the device after calling the UpdateFirmware method. The response request contains the DeviceIdentification and CorrelationUid which is received from the [UpdateFirmware](UpdateFirmware.md) request.
+GetUpdateFirmwareResponse returns the device firmware versions that are on the device after calling the UpdateFirmware method. The response contains the DeviceIdentification and CorrelationUid which is received from the [UpdateFirmware](UpdateFirmware.md) request.
 
 All requests have similar response behaviour which is described in [ResponseMessages](./ResponseMessages.md).
 

--- a/Domains/Smartmetering/smartmeteringwebservices/ReadAlarmRegister.md
+++ b/Domains/Smartmetering/smartmeteringwebservices/ReadAlarmRegister.md
@@ -5,7 +5,7 @@ ReadAlarmRegister is a request to retrieve the query alarm register. A notificat
 
 All requests have similar response behaviour which is described in [ResponseMessages](./ResponseMessages.md).
 
-[GetReadAlarmRegisterResponse](GetReadAlarmRegisterResponse.md) returns the alarm notifications from the ReadAlarmRegister request. The response request contains the DeviceIdentification and CorrelationUid which is received from the ReadAlarmRegister request.
+[GetReadAlarmRegisterResponse](GetReadAlarmRegisterResponse.md) returns the alarm notifications from the ReadAlarmRegister request. The response contains the DeviceIdentification and CorrelationUid which is received from the ReadAlarmRegister request.
 
 ### References
 

--- a/Domains/Smartmetering/smartmeteringwebservices/ReplaceKeys.md
+++ b/Domains/Smartmetering/smartmeteringwebservices/ReplaceKeys.md
@@ -5,7 +5,7 @@ ReplaceKeys is a request to change the keys on an E-meter. The request needs the
 
 All requests have similar response behaviour which is described in [ResponseMessages](./ResponseMessages.md).
 
-[GetReplaceKeysResponse](GetReplaceKeysResponse.md) returns if the result is successful from the ReplaceKeys request. The response request contains the DeviceIdentification and CorrelationUid which is received from the ReplaceKeys request.
+[GetReplaceKeysResponse](GetReplaceKeysResponse.md) returns if the result is successful from the ReplaceKeys request. The response contains the DeviceIdentification and CorrelationUid which is received from the ReplaceKeys request.
 
 ### References
 

--- a/Domains/Smartmetering/smartmeteringwebservices/ResponseMessages.md
+++ b/Domains/Smartmetering/smartmeteringwebservices/ResponseMessages.md
@@ -1,6 +1,6 @@
 ## ResponseMessages
 
 The response of a request should always contain a DeviceIdentification and CorrelationUid which is used in the response request. 
-Assertions validate if  there is a 'SOAP Response' received, if the response is 'Schema Compliance' with the WSDL and if there has been a 'not SOAP Fault'. 
-The last one occurs when a faultcode is returned. Possible faults are connection timed-out, SmartMeter could not be found, TCP-IP connection error or Correlationuid is unknown. 
+Assertions validate if there is a 'SOAP Response' received, if the response is 'Schema Compliant' with the WSDL and if there has been a 'not SOAP Fault'. 
+The last one occurs when a fault code is returned. Possible faults are connection timed-out, SmartMeter could not be found, TCP-IP connection error or Correlationuid is unknown. 
 The faults can be among others a FunctionalFault or TechnicalFault. Responses to a bundle request may include faults in the form of FaultResponseData, resembling the other faults. The format of these faults is described in the [common.xsd](https://github.com/OSGP/Platform/blob/development/osgp-adapter-ws-smartmetering/src/main/webapp/WEB-INF/wsdl/smartmetering/schemas/common.xsd).

--- a/Domains/Smartmetering/smartmeteringwebservices/RetrieveAllAttributeValues.md
+++ b/Domains/Smartmetering/smartmeteringwebservices/RetrieveAllAttributeValues.md
@@ -2,11 +2,11 @@
 
 ### Description
 RetrieveAllAttributeValues is a request to get the all attribute values of all the objects in the device tree and values from an E-meter. Because this is a big operation for a device, it can take up to 30 minutes to retrieve all the response information.
-The request is send with the DeviceIdentification number from the desired device.
+The request is sent with the DeviceIdentification number from the desired device.
 
 All requests have similar response behaviour which is described in [ResponseMessages](./ResponseMessages.md).
 
-[GetRetrieveAllAttributeValuesResponse](GetRetrieveAllAttributeValuesResponse.md) returns the result values from getting all the attribute values. The response request contains the DeviceIdentification and CorrelationUid which is received from the RetrieveAllAttributeValues request.
+[GetRetrieveAllAttributeValuesResponse](GetRetrieveAllAttributeValuesResponse.md) returns the result values from getting all the attribute values. The response contains the DeviceIdentification and CorrelationUid which is received from the RetrieveAllAttributeValues request.
 
 ### References
 

--- a/Domains/Smartmetering/smartmeteringwebservices/SetActivityCalendar.md
+++ b/Domains/Smartmetering/smartmeteringwebservices/SetActivityCalendar.md
@@ -1,13 +1,13 @@
 ## SetActivityCalendar request
 
 ### Description
-SetActivityCalendar is a request to set tarrifs on an E-meter according a SeasonProfile and WeekProfile. In a WeekProfile, seven dayprofiles can be filled in with a starttime and dayId which contains the tariff. 
+SetActivityCalendar is a request to set tariffs on an E-meter according a SeasonProfile and WeekProfile. In a WeekProfile, seven dayprofiles can be filled in with a start time and dayId which contains the tariff. 
 
 The request needs the DeviceIdentification, CalendarName, ActivatePassiveCalendarTime, SeasonProfileName, SeasonStart, WeekProfileName, DayId and StartTime.
 
 All requests have similar response behaviour which is described in [ResponseMessages](./ResponseMessages.md).
 
-[GetSetActivityCalendarResponse](GetSetActivityCalendarResponse.md) returns the result from setting a SetActivityCalendar. The response request contains the DeviceIdentification and CorrelationUid which is received from the SetActivityCalendar request.
+[GetSetActivityCalendarResponse](GetSetActivityCalendarResponse.md) returns the result from setting a SetActivityCalendar. The response contains the DeviceIdentification and CorrelationUid which is received from the SetActivityCalendar request.
 
 ### References
 

--- a/Domains/Smartmetering/smartmeteringwebservices/SetAdministrativeStatus.md
+++ b/Domains/Smartmetering/smartmeteringwebservices/SetAdministrativeStatus.md
@@ -5,7 +5,7 @@ SetAdministrativeStatusis a request to set the AdministrativeStatus on a device.
 
 All requests have similar response behaviour which is described in [ResponseMessages](./ResponseMessages.md).
 
-[GetSetAdministrativeStatusResponse](GetSetAdministrativeStatusResponse.md) returns if the setting SetAdministrativeStatus is enabled. The response request contains the DeviceIdentification and CorrelationUid which is received from the SetAdministrativeStatus request.
+[GetSetAdministrativeStatusResponse](GetSetAdministrativeStatusResponse.md) returns if the setting SetAdministrativeStatus is enabled. The response contains the DeviceIdentification and CorrelationUid which is received from the SetAdministrativeStatus request.
 
 ### References
 

--- a/Domains/Smartmetering/smartmeteringwebservices/SetAlarmNotifications.md
+++ b/Domains/Smartmetering/smartmeteringwebservices/SetAlarmNotifications.md
@@ -1,7 +1,7 @@
 ## SetAlarmNotifications request
 
 ### Description
-SetAlarmNotifications is a request to set the types of alarmnotifications that must be notified from the device when they occur.
+SetAlarmNotifications is a request to set the types of alarm notifications that must be notified from the device when they occur.
 The following notifications can be enabled or disabled:
 
 CLOCK_INVALID, REPLACE_BATTERY, POWER_UP, PROGRAM_MEMORY_ERROR, RAM_ERROR, NV_MEMORY_ERROR, MEASUREMENT_SYSTEM_ERROR, WATCHDOG_ERROR, FRAUD_ATTEMPT, COMMUNICATION_ERROR_M_BUS_CHANNEL_1, COMMUNICATION_ERROR_M_BUS_CHANNEL_2, COMMUNICATION_ERROR_M_BUS_CHANNEL_3, COMMUNICATION_ERROR_M_BUS_CHANNEL_4, FRAUD_ATTEMPT_M_BUS_CHANNEL_1, FRAUD_ATTEMPT_M_BUS_CHANNEL_2, FRAUD_ATTEMPT_M_BUS_CHANNEL_3, FRAUD_ATTEMPT_M_BUS_CHANNEL_4, NEW_M_BUS_DEVICE_DISCOVERED_CHANNEL_1, NEW_M_BUS_DEVICE_DISCOVERED_CHANNEL_2, NEW_M_BUS_DEVICE_DISCOVERED_CHANNEL_3, NEW_M_BUS_DEVICE_DISCOVERED_CHANNEL_4
@@ -10,7 +10,7 @@ The request needs the DeviceIdentification, AlarmType and Enabled parameters.
 
 All requests have similar response behaviour which is described in [ResponseMessages](./ResponseMessages.md).
 
-[GetSetAlarmNotificationsResponse](GetSetAlarmNotificationsResponse.md) returns the result from setting a SetAlarmNotifications. The response request contains the DeviceIdentification and CorrelationUid which is received from the SetAlarmNotifications request.
+[GetSetAlarmNotificationsResponse](GetSetAlarmNotificationsResponse.md) returns the result from setting a SetAlarmNotifications. The response contains the DeviceIdentification and CorrelationUid which is received from the SetAlarmNotifications request.
 
 ### References
 

--- a/Domains/Smartmetering/smartmeteringwebservices/SetConfigurationObject.md
+++ b/Domains/Smartmetering/smartmeteringwebservices/SetConfigurationObject.md
@@ -17,7 +17,7 @@ See DSMR document chapter 8.3 for detailed description. The request needs the De
 
 All requests have similar response behaviour which is described in [ResponseMessages](./ResponseMessages.md).
 
-[GetSetConfigurationObjectResponse](GetSetConfigurationObjectResponse.md) returns the result from setting a SetConfigurationObject. The response request contains the DeviceIdentification and CorrelationUid which is received from the SetConfigurationObject request.
+[GetSetConfigurationObjectResponse](GetSetConfigurationObjectResponse.md) returns the result from setting a SetConfigurationObject. The response contains the DeviceIdentification and CorrelationUid which is received from the SetConfigurationObject request.
 
 ### References
 

--- a/Domains/Smartmetering/smartmeteringwebservices/SetEncryptionKeyExchangeOnGMeter.md
+++ b/Domains/Smartmetering/smartmeteringwebservices/SetEncryptionKeyExchangeOnGMeter.md
@@ -5,7 +5,7 @@ SetEncryptionKeyExchangeOnGMeter is a request to transfer and set a G-meter key 
 
 All requests have similar response behaviour which is described in [ResponseMessages](./ResponseMessages.md).
 
-[GetSetEncryptionKeyExchangeOnGMeterResponse](GetSetEncryptionKeyExchangeOnGMeterResponse.md) returns the result from setting a SetEncryptionKeyExchangeOnGMeter. The response request contains the DeviceIdentification and CorrelationUid which is received from the SetEncryptionKeyExchangeOnGMeter request.
+[GetSetEncryptionKeyExchangeOnGMeterResponse](GetSetEncryptionKeyExchangeOnGMeterResponse.md) returns the result from setting a SetEncryptionKeyExchangeOnGMeter. The response contains the DeviceIdentification and CorrelationUid which is received from the SetEncryptionKeyExchangeOnGMeter request.
 
 ### References
 

--- a/Domains/Smartmetering/smartmeteringwebservices/SetPushSetupAlarm.md
+++ b/Domains/Smartmetering/smartmeteringwebservices/SetPushSetupAlarm.md
@@ -5,7 +5,7 @@ SetPushSetupAlarm is a request to push a received alarm notification from a devi
 
 All requests have similar response behaviour which is described in [ResponseMessages](./ResponseMessages.md).
 
-[GetSetPushSetupAlarmResponse](GetSetPushSetupAlarmResponse.md) returns the result from setting a SetPushSetupAlarm. The response request contains the DeviceIdentification and CorrelationUid which is received from the SetPushSetupAlarm request.
+[GetSetPushSetupAlarmResponse](GetSetPushSetupAlarmResponse.md) returns the result from setting a SetPushSetupAlarm. The response contains the DeviceIdentification and CorrelationUid which is received from the SetPushSetupAlarm request.
 
 ### References
 

--- a/Domains/Smartmetering/smartmeteringwebservices/SetPushSetupSms.md
+++ b/Domains/Smartmetering/smartmeteringwebservices/SetPushSetupSms.md
@@ -1,12 +1,12 @@
 ## SetPushSetupSms request
 
 ### Description
-SetPushSetupSms is a request to set an endpoint in a device which tells the device where to connect to when it is waked up.
+SetPushSetupSms is a request to set an endpoint in a device which tells the device where to connect to when it is woken.
 The request needs the DeviceIdentification, host URL and port.
 
 All requests have similar response behaviour which is described in [ResponseMessages](./ResponseMessages.md).
 
-[GetSetPushSetupSmsResponse](GetSetPushSetupSmsResponse.md) returns the result from setting a SetPushSetupSms. The response request contains the DeviceIdentification and CorrelationUid which is received from the SetPushSetupSms request.
+[GetSetPushSetupSmsResponse](GetSetPushSetupSmsResponse.md) returns the result from setting a SetPushSetupSms. The response contains the DeviceIdentification and CorrelationUid which is received from the SetPushSetupSms request.
 
 ### References
 

--- a/Domains/Smartmetering/smartmeteringwebservices/SetSpecialDays.md
+++ b/Domains/Smartmetering/smartmeteringwebservices/SetSpecialDays.md
@@ -1,12 +1,12 @@
 ## SetSpecialDays request
 
 ### Description
-SetSpecialDays is a request to set a dayId profile for a specific date on a device, other than the standard applicable dayId's. This can be usefull to change tariffs and tariff scheduling for specific days such as public holidays.
+SetSpecialDays is a request to set a dayId profile for a specific date on a device, other than the standard applicable dayId's. This can be useful to change tariffs and tariff scheduling for specific days such as public holidays.
 The request is send with the DeviceIdentification number from the desired device, date and dayId.
 
 All requests have similar response behaviour which is described in [ResponseMessages](./ResponseMessages.md).
 
-[GetSetSpecialDaysResponse](GetSetSpecialDaysResponse.md) returns the result from setting a Special Day. The response request contains the DeviceIdentification and CorrelationUid which is received from the SetSpecialDays request.
+[GetSetSpecialDaysResponse](GetSetSpecialDaysResponse.md) returns the result from setting a Special Day. The response contains the DeviceIdentification and CorrelationUid which is received from the SetSpecialDays request.
 
 ### References
 

--- a/Domains/Smartmetering/smartmeteringwebservices/SynchronizeTime.md
+++ b/Domains/Smartmetering/smartmeteringwebservices/SynchronizeTime.md
@@ -6,7 +6,7 @@ For example in Central European Summer Time, DST is active and times are UTC/GMT
 
 All requests have similar response behaviour which is described in [ResponseMessages](./ResponseMessages.md).
 
-[GetSynchronizeTimeResponse](./GetSynchronizeTimeResponse.md) returns the result from synchronizing date and time. The response request contains the DeviceIdentification and CorrelationUid which is received from the SynchronizeTime request.
+[GetSynchronizeTimeResponse](./GetSynchronizeTimeResponse.md) returns the result from synchronizing date and time. The response contains the DeviceIdentification and CorrelationUid which is received from the SynchronizeTime request.
 
 ### References
 

--- a/Domains/Smartmetering/smartmeteringwebservices/UpdateFirmware.md
+++ b/Domains/Smartmetering/smartmeteringwebservices/UpdateFirmware.md
@@ -5,7 +5,7 @@ UpdateFirmware is a request to install another firmware version(s) on a device. 
 
 All requests have similar response behaviour which is described in [ResponseMessages](./ResponseMessages.md).
 
-[GetUpdateFirmwareResponse](GetUpdateFirmwareResponse.md) returns the version(s). The response request contains the DeviceIdentification and CorrelationUid which is received from the UpdateFirmware request.
+[GetUpdateFirmwareResponse](GetUpdateFirmwareResponse.md) returns the version(s). The response contains the DeviceIdentification and CorrelationUid which is received from the UpdateFirmware request.
 
 ### References
 

--- a/Domains/Smartmetering/smartmeteringwebservices/bundeling.md
+++ b/Domains/Smartmetering/smartmeteringwebservices/bundeling.md
@@ -3,7 +3,6 @@
 You can combine multiple requests to a meter in a bundle by creating a BundleRequest with one or more Actions in the namespace
 http://www.alliander.com/schemas/osgp/smartmetering/sm-bundle/2014/10. Each Action contains one of the existing requests to a meter.
 
-A bundle is executed using one connection to the meter. A bundle response contains all indivudual responses of executed commands
-both succesful and unsuccessful. When an individual request fails it is retried when this is useful, more precisely the bundle
-is retried, executing only requests that are retryable.
-
+A bundle is executed using one connection to the meter. A bundle response contains all individual responses of executed commands
+both successful and unsuccessful. When an individual request fails it is retried when this is useful, more precisely the bundle
+is retried, executing only requests that are fit for re-submission.

--- a/Domains/Tariffswitching/README.md
+++ b/Domains/Tariffswitching/README.md
@@ -2,7 +2,7 @@
 This covers the services for tariff switching domain using the open smart grid platform.
 
 ##Scope
-This domain allows tariff switching. It allows a relays to switch when a tariff changes. 
+This domain allows tariff switching. It allows a relay to switch when a tariff changes. 
 This domain could be used to replace ripple control tariff signals.
 
 ### Webservices

--- a/Opensourcecommunity/Communication-and-contact.md
+++ b/Opensourcecommunity/Communication-and-contact.md
@@ -8,15 +8,15 @@ Once we get the foundation going, we will open an address so you can directly co
 
 ## Jira
 
-Jira was chosen due to its extensive features. The current [Jira](https://smartsocietyservices.atlassian.net/projects/OC/issues/) board is sponsored by Smart society services for synergy reasons. 
-Once we have multilple contributors outside Smart society services we can move to a dedicated jira instance or something else.
+Jira was chosen due to its extensive features. The current [Jira](https://smartsocietyservices.atlassian.net/projects/OC/issues/) board is sponsored by Smart Society Services for synergy reasons. 
+Once we have multiple contributors outside Smart Society Services we can move to a dedicated Jira instance or something else.
 
-Once you get actively involved, you can request write permissions on the jira board.
+Once you get actively involved, you can request write permissions on the Jira board.
 You can request write access to the Jira issue board by sending a request to opensource@smartsocietyservices.com (Marcel checks this mailbox for Jira requests).
 
 ### New Features
 
-1. If there is a need (or wish!) for a new feature, add it as issue to [Jira](https://smartsocietyservices.atlassian.net/projects/OC/issues/) as a user story. Please provide a full description about the background of the problem. Spilt-up big userstories in multiple small user stories.
+1. If there is a need (or wish!) for a new feature, add it as issue to [Jira](https://smartsocietyservices.atlassian.net/projects/OC/issues/) as a user story. Please provide a full description about the background of the problem. Spilt-up big user stories in multiple small user stories.
 
 2. A developer can take on the issue and start working on it on voluntary base. If you need this feature and you have the money to pay for it, you can hire a developer and have the developer work on it. If open smart grid platform core components are involved, please discuss your change first with one of the developers/maintainers.
 

--- a/Opensourcecommunity/Contributing-to-documentation.md
+++ b/Opensourcecommunity/Contributing-to-documentation.md
@@ -27,7 +27,7 @@ We encourage you to participate in improving the documentation. From corrected t
 
 5. Assign a maintainer or other developer on this topic to accept/evaluate your pull request. The current maintainer can be found in the [governance paragraph](../Opensourcecommunity/Governance).
 
-Some information on GitBook and using Markdown can be found [here](http://help.gitbook.com/), more elaborate information on GitHub-flavored Markdown is found [here](https://help.github.com/articles/github-flavored-markdown/). If you like to upload illustation, you can use git or [Github](https://help.github.com/articles/adding-a-file-to-a-repository/)
+Some information on GitBook and using Markdown can be found [here](http://help.gitbook.com/), more elaborate information on GitHub-flavored Markdown is found [here](https://help.github.com/articles/github-flavored-markdown/). If you like to upload illustration, you can use git or [Github](https://help.github.com/articles/adding-a-file-to-a-repository/)
 
 If you are completely new to this and you need help to get started, file an issue in the documentation repository.
 

--- a/Opensourcecommunity/Contributing-to-the-code.md
+++ b/Opensourcecommunity/Contributing-to-the-code.md
@@ -9,7 +9,7 @@ Before code is merged it needs to comply with a number of guidelines:
 2. Right formatting; code should follow the Coding Conventions (see 3.1.2)
 3. Fixed/added unit tests where applicable
 4. Javadocs added where applicable
-5. Accepting pull-requests with SonarQube reports "Blocker" and "Critical" and are not allowed
+5. Accepting pull-requests with SonarQube reports "Blocker" and "Critical" are not allowed
 6. Comply with International open standards where possible (e.g. IEC standards)
 
 ### Contributor License Agreement
@@ -30,7 +30,7 @@ If the changes fix a bug, mention the issue number in the commit message or pull
 The open smart grid platform's main branch is master. All major releases are tagged in this branch. Development is done in
 the development and feature branches. We use the GitFlow branching strategy. Find more information on this strategy here: [GitFlow](http://nvie.com/posts/a-successful-git-branching-model/)
 
-The GitFlow work flow is someone complicated, but it has the advantage that it gives a clear overview of all previous releases and current development and thus helps to collaborate more efficiently. Please follow this strategy in your commits.
+The GitFlow workflow is someone complicated, but it has the advantage that it gives a clear overview of all previous releases and current development and thus helps to collaborate more efficiently. Please follow this strategy in your commits.
 
 ### Pull requests: review process
 

--- a/Opensourcecommunity/Foundation.md
+++ b/Opensourcecommunity/Foundation.md
@@ -1,11 +1,8 @@
 ## Foundation
 
-The Foundation will be an independent organisation to support and promote the open smart grid platform development (The foundation is not started yet). The foundation will be similar to the Linux foundation or Apache foundation. The Foundation will start once we have multiple founding members. If you like to support the Foundation, contact us: opensource@smartsocietyservices.com
+The Foundation will be an independent organisation to support and promote the open smart grid platform development (the foundation is not started yet). The foundation will be similar to the Linux foundation or Apache foundation. The Foundation will start once we have multiple founding members. If you like to support the Foundation, contact us: opensource@smartsocietyservices.com. This foundation will promote and facilitate the use of and future development of the Open Smart Grid Platform. In addition, the Foundation will support the community of developers and users of the Open Smart Grid Platform to accelerate future development and to develop a larger user base of the platform. This foundation will encourage the development of the ecosystem.
 
-
-To ensure future and independent development of the platform, the open smart grid platform founders founded an independent software foundation. This foundation promotes and facilitates the use of and future development of the Open Smart Grid Platform. In addition, the Foundation also supports the community of developers and users of the Open Smart Grid Platform to accelerate future development and to develop a larger user base of the platform. This foundation also encourages the development of the ecosystem.
-
-The foundation is for non-profit. Our aim is that companies / organizations can make a sponsorship contribution to the foundation, in order to support the use and development of the open source platform.
+The foundation will be non-profit. Our aim is that companies / organizations can make a sponsorship contribution to the foundation, in order to support the use and development of the open source platform.
 
 Planned key activities of the foundation are:
 

--- a/Opensourcecommunity/Getstarted.md
+++ b/Opensourcecommunity/Getstarted.md
@@ -1,6 +1,6 @@
 This is a guide to start contributing to the open smart grid platform project:
 
-1. Make yourself comfortable with with the open smart grid platform by e.g. installing it.
+1. Make yourself comfortable with the open smart grid platform by e.g. installing it.
 2. Read the documentation to get an idea of how the software works (architecture chapter), how the community works (this chapter).
 3. Find an open issue to work on or fire an new issue.
 4. Assign yourself to the issue and start contributing.

--- a/Opensourcecommunity/ToolsguidelinesCI.md
+++ b/Opensourcecommunity/ToolsguidelinesCI.md
@@ -16,7 +16,7 @@ The technology and tools used can be found in the [Technology stack](../Architec
 
 ## Continuous Integration
 
-All changes pushed to GitHub are built by our buildserver. Pull requests to master branch or development branch are also built. SonarQube performs static code analysis to help improve the quality level of the code base.
+All changes pushed to GitHub are built by our build server. Pull requests to master branch or development branch are also built. SonarQube performs static code analysis to help improve the quality level of the code base.
 
 - [Jenkins buildserver](http://ci.opensmartgridplatform.org): An open source continuous integration tool written in Java.
 - [SonarQube](http://ci.opensmartgridplatform.org/sonarqube): SonarQube is an open platform to manage code quality.
@@ -64,4 +64,4 @@ Protocol Adapter components translate a message from domain adapter components i
 
 #### OSLP
 
-For the OSLP implementation, 2 components are used. The first component is the protocol adapter for the protocol. It can translate message into the protocol message for SSLD's. Second there's the signing-server component. It is responsible for signing the protocol message using the private key of the platform. The components communicate using a queue-pair. The singing-server can handle multiple protocol adapter instances by utilizing a reply-to queue per protocol adapter instance. Since the protocol adapter component needs to be reachable from a network, it is a requirement that the private key may not be used by the protocol adapter directly. The singing-server component  can be deployed in such a way that no network access is available to this component, as the only coupling needed are the queues / the message broker.
+For the OSLP implementation, two components are used. The first component is the protocol adapter for the protocol. It can translate message into the protocol message for SSLD's. Second there's the signing-server component. It is responsible for signing the protocol message using the private key of the platform. The components communicate using a key-pair. The signing-server can handle multiple protocol adapter instances by utilizing a reply-to queue per protocol adapter instance. Since the protocol adapter component needs to be reachable from a network, it is a requirement that the private key may not be used by the protocol adapter directly. The signing server component can be deployed in such a way that no network access is available to this component, as the only coupling needed are the queues / the message broker.

--- a/Protocols/DLMS/README.md
+++ b/Protocols/DLMS/README.md
@@ -1,11 +1,11 @@
 ##DLMS/COSEM
-The open smart grid platform supports DLMS/COSEM ([IEC 62056](https://en.wikipedia.org/wiki/IEC_62056)]. DLMS/COSEM is a popular protocol to read smart meters. DLMS/COSEM is the defacto standard in Europe.
+The open smart grid platform supports DLMS/COSEM ([IEC 62056](https://en.wikipedia.org/wiki/IEC_62056)]. DLMS/COSEM is a popular protocol to read smart meters. DLMS/COSEM is the de facto standard in Europe.
 
 The open smart grid platform DLMS/COSEM implementation was initial based on SMR5 and DSMR [v4](http://www.netbeheernederland.nl/themas/hotspot/hotspot-documenten/?dossierid=11010056&title=Slimme%20meter&onderdeel=Documenten).
 Other types of meters/profiles can be added to the platform. The open smart grid platform implementation supports HLS3/4/5.
 
 ## Protocol security
-* Public/private keypair(s)
+* Public/private key pair(s)
 * Multiple encryption levels inside protocol (DSMR requires highest encryption level)
 * Full encryption of communication
 

--- a/Protocols/OSLP/README.md
+++ b/Protocols/OSLP/README.md
@@ -4,13 +4,13 @@
 ## The Open Street Light Protocol
 
 The OSLP is a lightweight message based protocol. 
-OSLP uses [Google Protocol Buffers](https://developers.google.com/protocol-buffers/?hl=en) and is used for communication with SSLD devices (and device simulators). It is defined as a contract/interface. The interface defines datatypes and messages which use those datatypes.
+OSLP uses [Google Protocol Buffers](https://developers.google.com/protocol-buffers/?hl=en) and is used for communication with SSLD devices (and device simulators). It is defined as a contract/interface. The interface defines datatypes and messages which use those data types.
 Google Protocol Buffers is used to generate the protocol implementations for Java (for the platform) and C/C++ (for the SSLD devices).
 
 Open street light protocol does not use ASN.1 but Google Protocol Buffers. The main reason for this is the lack of a good quality free ASN.1 compiler for Java or C. Google Protocol Buffers offers a fast and free compiler for Java and C which produces small message sizes.
 
 ## Protocol security
-* Public/private keypair
+* Public/private key pair
 * Signing of messages through Elliptic Curve DSA 256 bit
 ** Integrity of the message is ensured 
 ** Sender identity is ensured

--- a/Protocols/OSLP/v0.5.1/RegisterDevice.md
+++ b/Protocols/OSLP/v0.5.1/RegisterDevice.md
@@ -4,7 +4,7 @@
 
 Note: the device registration is a 2 step process. First RegisterDeviceRequest and RegisterDeviceResponse are exchanged between device and platform. Second [ConfirmRegisterDeviceRequest and ConfirmRegisterDeviceResponse messages](ConfirmRegisterDevice.md) are exchanged.
 
-Request that notifies the platform a device which wants to register. During the registration the sequence number is reset to a random value the platform is notified if the device has a light schedule, the type of the device, the device identification, and the device communicates it's IP address to the platform. Also a random number is determined by the device and this 'randomDevice' should be present in the response form the platform.
+Request that notifies the platform a device which wants to register. During the registration the sequence number is reset to a random value the platform is notified if the device has a light schedule, the type of the device, the device identification, and the device communicates its IP address to the platform. Also a random number is determined by the device and this 'randomDevice' should be present in the response form the platform.
 
 Response which holds the time of the platform so the device can synchronize the time, contains location information for the device like GPS coordinates and Daylight Saving Time information. The device will sent ConfirmRegisterDeviceRequest after receiving the RegisterDeviceResponse. Also a random number is determined by the platform and this 'randomPlatform' should be present in the next request 'ConfirmRegisterDeviceRequest' by the device.
 

--- a/Protocols/OSLP/v0.5.1/ResumeSchedule.md
+++ b/Protocols/OSLP/v0.5.1/ResumeSchedule.md
@@ -19,7 +19,7 @@ message ResumeScheduleResponse {
 }
 ```
 
-### Datatypes
+### Data types
 
 ``` json
 enum Status {

--- a/Protocols/OSLP/v0.5.1/SetConfiguration.md
+++ b/Protocols/OSLP/v0.5.1/SetConfiguration.md
@@ -26,7 +26,7 @@ message SetConfigurationResponse {
 
 ```
 
-### Datatypes
+### Data types
 
 ``` json
 enum LightType {

--- a/Protocols/OSLP/v0.5.1/SetEventNotifications.md
+++ b/Protocols/OSLP/v0.5.1/SetEventNotifications.md
@@ -18,7 +18,7 @@ message SetEventNotificationsResponse {
 }
 ```
 
-### Datatypes
+### Data types
 
 ``` json
 enum Status {

--- a/Protocols/OSLP/v0.5.1/SetLight.md
+++ b/Protocols/OSLP/v0.5.1/SetLight.md
@@ -21,7 +21,7 @@ message SetLightResponse {
 }
 ```
 
-### Datatypes
+### Data types
 
 ``` json
 message LightValue {

--- a/Protocols/OSLP/v0.5.1/SetReboot.md
+++ b/Protocols/OSLP/v0.5.1/SetReboot.md
@@ -18,7 +18,7 @@ message SetRebootResponse {
 }
 ```
 
-### Datatypes
+### Data types
 
 ``` json
 enum Status {

--- a/Protocols/OSLP/v0.5.1/SetSchedule.md
+++ b/Protocols/OSLP/v0.5.1/SetSchedule.md
@@ -20,7 +20,7 @@ message SetScheduleResponse {
 }
 ```
 
-### Datatypes
+### Data types
 
 ``` json
 message Schedule {

--- a/Protocols/OSLP/v0.5.1/SetTransition.md
+++ b/Protocols/OSLP/v0.5.1/SetTransition.md
@@ -21,7 +21,7 @@ message SetTransitionResponse {
 }
 ```
 
-### Datatypes
+### Data types
 
 ``` json
 enum TransitionType {

--- a/Protocols/OSLP/v0.5.1/StartSelfTest.md
+++ b/Protocols/OSLP/v0.5.1/StartSelfTest.md
@@ -18,7 +18,7 @@ message StartSelfTestResponse {
 }
 ```
 
-### Datatypes
+### Data types
 
 ``` json
 enum Status {

--- a/Protocols/OSLP/v0.5.1/StopSelfTest.md
+++ b/Protocols/OSLP/v0.5.1/StopSelfTest.md
@@ -19,7 +19,7 @@ message StopSelfTestResponse {
 }
 ```
 
-### Datatypes
+### Data types
 
 ``` json
 enum Status {

--- a/Protocols/OSLP/v0.5.1/UpdateFirmware.md
+++ b/Protocols/OSLP/v0.5.1/UpdateFirmware.md
@@ -19,7 +19,7 @@ message UpdateFirmwareResponse {
 }
 ```
 
-### Datatypes
+### Data types
 
 ``` json
 enum Status {

--- a/Protocols/README.md
+++ b/Protocols/README.md
@@ -1,5 +1,5 @@
 ## Protocols
-The open smart grid platform supported protocols can be found in this section.Feel free to add your own protocol or improve an exsisting protocol adaptor.
+The open smart grid platform supported protocols can be found in this section. Feel free to add your own protocol or improve an existing protocol adapter.
 
 ### Protocol Adapters
 

--- a/Support/README.md
+++ b/Support/README.md
@@ -6,7 +6,7 @@ There are multiple options for support
 Community members can help you on voluntary basis. See the open source and community section for more information where you can ask your questions.
 
 ## Commercial support
-If you'd like professional support for your Open Smart Grid Platform use case, consider support of one of the companies below.
+If you'd like professional support for your Open Smart Grid Platform use case, consider support by one of the companies below.
 
 Smart Society Services
 - Website: http://smartsocietyservices.com

--- a/Userguide/Installation/installation.md
+++ b/Userguide/Installation/installation.md
@@ -2,5 +2,5 @@
 
 To install the platform you can use one of the following procedures.
 
-1. [The Vagrant Installation](./Setup-VM-Vagrant.md). This procedure creates and installs a complete image with the Open Smart Grid Platform pre-installed, inlcuding all the tools such as Maven, Eclipse, Soap Ui, etc.
+1. [The Vagrant Installation](./Setup-VM-Vagrant.md). This procedure creates and installs a complete image with the Open Smart Grid Platform pre-installed, including all the tools such as Maven, Eclipse, Soap Ui, etc.
 2. [The Manual Installation](./manualInstallation.md). Follow this guide if you want to install the Open Smart Grid Platform yourself.

--- a/Userguide/Installation/manualInstallation.md
+++ b/Userguide/Installation/manualInstallation.md
@@ -60,7 +60,7 @@ git clone https://github.com/OSGP/Documentation.git /home/dev/Sources/OSGP/Docum
 ```
 Make sure you are on the development branch (default).
 
-Initialiaze the Git submodules in Platform, Protocol-Adapter-OSLP, Protocol-Adapter-DLMS, Protocol-Adapter-IEC61850 and Integration-Tests by running the following command in each directory:
+Initialize the Git submodules in Platform, Protocol-Adapter-OSLP, Protocol-Adapter-DLMS, Protocol-Adapter-IEC61850 and Integration-Tests by running the following command in each directory:
 ```shell
 git submodule update --init --recursive
 ```
@@ -97,5 +97,3 @@ service postgresql reload
 ### Set up the Open Smart Grid Platform
 
 Continue with setting up the Open Smart Grid Platform by following the [Set up the Open Smart Grid Platform Guide](http://documentation.opensmartgridplatform.org/Userguide/Installation/setupOSGP.html)
-
-

--- a/Userguide/addOrganisation.md
+++ b/Userguide/addOrganisation.md
@@ -85,7 +85,7 @@ Now that the certificate has been created, restart the tomcat server.
 
 ### Signing a request with the new certificate
 
-When the tomcat server is up and running again, go to SoapUi and add the new certificate to the pubblic-lighting project: double-click on the project, go to the WS-Security Configurations tab and select the keystores tab. Click the '+' button and browse to the my-org.pfx certificate which can be found in `/home/dev/Sources/OSGP/Config/certificates/osgp-ca/certs/`
+When the tomcat server is up and running again, go to SoapUi and add the new certificate to the public-lighting project: double-click on the project, go to the WS-Security Configurations tab and select the keystores tab. Click the '+' button and browse to the my-org.pfx certificate which can be found in `/home/dev/Sources/OSGP/Config/certificates/osgp-ca/certs/`
 
 ![alt text](screenshots/02.png)
 
@@ -137,4 +137,4 @@ Send the new request, you should receive the following response:
 
 Check the device-simulator to see if the dimValue of the SSLD_000-00-01 changed to 50.
 
-You now have succesfully created a new organisation, along with a certificate to sign the requests, and changed the device authorisations of the device to accept commands from the new organisation.
+You now have successfully created a new organisation, along with a certificate to sign the requests, and changed the device authorisations of the device to accept commands from the new organisation.


### PR DESCRIPTION
Fixed numerous language issues, for example;
* webservices ==> web services, datatypes=>data types
* response request => response (in the SOAP message documentation)
* various typos, double words (e.g. request request, etc.)
* etc.

In general I did not alter the semantics of the text, only in places where the text was either ambiguous or just wrong.