### PR TITLE
OC-177 ~ Updates links to PDF version of documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Web
 * [Latest Pull-request publication](http://documentation.opensmartgridplatform.org/documentation-pr)
 
 PDF
-* [Development branch publication in PDF](http://documentation.opensmartgridplatform.org/documentation-pdf)
+* [Development branch publication in PDF](http://documentation.opensmartgridplatform.org/osgp-documentation.pdf)
 
 
 ## Open smart grid platform information and news

--- a/book.json
+++ b/book.json
@@ -17,7 +17,7 @@
     },
     "links": {
 		"sidebar": {
-			"Download as PDF": "http://documentation.opensmartgridplatform.org/documentation-pdf"
+			"Download as PDF": "http://documentation.opensmartgridplatform.org/osgp-documentation.pdf"
 		},
         "home": null,
         "about": false,


### PR DESCRIPTION
- a PDF version is now generated during builds for master, development and release branches, plus for pull requests
- the link has been changed to: http://documentation.opensmartgridplatform.org/osgp-documentation.pdf , which is the development PDF version
