### PR TITLE
SLIM-1775 Updates Scan M-Bus Channels documentation for the Short IDs

### DIFF
--- a/Domains/Smartmetering/README.md
+++ b/Domains/Smartmetering/README.md
@@ -36,7 +36,7 @@ Currently, the following Smart Metering features are available within the open s
 - **[GetSpecificAttributeValueResponse](./smartmeteringwebservices/GetSpecificAttributeValueResponse.md)** is an operation which returns the response from the [GetSpecificAttributeValue](./smartmeteringwebservices/GetSpecificAttributeValue.md) operation.
 - **[GetAssociationLnObjects](./smartmeteringwebservices/GetAssociationLnObjects.md)** is an operation to get the associated ln objects.
 - **[GetGetAssociationLnObjectsResponse](./smartmeteringwebservices/GetGetAssociationLnObjectsResponse.md)** is an operation which gets the response from the [GetAssociationLnObjects](./smartmeteringwebservices/GetAssociationLnObjects.md) operation.
-- **[ScanMbusChannels](./smartmeteringwebservices/ScanMbusChannels.md)** is an operation to get the M-Bus attribute values for all four channels from an E-meter.
+- **[ScanMbusChannels](./smartmeteringwebservices/ScanMbusChannels.md)** is an operation to get the M-Bus Short ID attribute values for all four channels from an E-meter.
 - **[ScanMbusChannelsResponse](./smartmeteringwebservices/ScanMbusChannelsResponse.md)** is an operation which returns the response from the [ScanMbusChannels](./smartmeteringwebservices/ScanMbusChannels.md) operation.
 
 #### SmartMeteringConfiguration

--- a/Domains/Smartmetering/smartmeteringwebservices/ScanMbusChannels.md
+++ b/Domains/Smartmetering/smartmeteringwebservices/ScanMbusChannels.md
@@ -1,7 +1,7 @@
 ## ScanMbusChannels request
 
 ### Description
-ScanMbusChannels is a request to read the M-Bus identification number from all four channels on a Gateway device to determine if a M-Bus device is bound on a channel of the Gateway device.
+ScanMbusChannels is a request to read the M-Bus Short Equipment Identifier (Short ID) attributes (Identification number, Manufacturer identification, Version identification, and Device type identification) from all four channels on a Gateway device to determine if an M-Bus device is bound on a channel of the Gateway device.
 
 All requests have similar response behaviour which is described in [ResponseMessages](./ResponseMessages.md).
 

--- a/Domains/Smartmetering/smartmeteringwebservices/ScanMbusChannelsResponse.md
+++ b/Domains/Smartmetering/smartmeteringwebservices/ScanMbusChannelsResponse.md
@@ -1,7 +1,7 @@
 ## ScanMbusChannelsResponse request
 
 ### Description
-ScanMbusChannelsResponse returns the result of a [ScanMbusChannels](ScanMbusChannels.md) request. The response contains the the M-Bus Short Equipment Identifier (Short ID) attributes (Identification number, Manufacturer identification, Version identification, and Device type identification) from all four channels of a Gateway device.
+ScanMbusChannelsResponse returns the result of a [ScanMbusChannels](ScanMbusChannels.md) request. The response contains the M-Bus Short Equipment Identifier (Short ID) attributes (Identification number, Manufacturer identification, Version identification, and Device type identification) from all four channels of a Gateway device.
 
 ### References
 

--- a/Domains/Smartmetering/smartmeteringwebservices/ScanMbusChannelsResponse.md
+++ b/Domains/Smartmetering/smartmeteringwebservices/ScanMbusChannelsResponse.md
@@ -1,7 +1,7 @@
 ## ScanMbusChannelsResponse request
 
 ### Description
-ScanMbusChannelsResponse returns the result of a [ScanMbusChannels](ScanMbusChannels.md) request. The response contains the M-Bus identification number from all four channels of a Gateway device.
+ScanMbusChannelsResponse returns the result of a [ScanMbusChannels](ScanMbusChannels.md) request. The response contains the the M-Bus Short Equipment Identifier (Short ID) attributes (Identification number, Manufacturer identification, Version identification, and Device type identification) from all four channels of a Gateway device.
 
 ### References
 


### PR DESCRIPTION
On Scan M-Bus Channels all attributes identifying the M-Bus device per
channel should be returned. These are represented conform the M-Bus
Short Equipment Identifier (Short ID) attributes (Identification number,
Manufacturer identification, Version identification, Device type
identification).

This updates the documentation, that only mentioned the M-Bus
Identification numbers to be returned.