### PR TITLE
Removed link to Jira

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,3 @@ High-level project information and news can be found on the Grid eXchange Fabric
 
 Grid eXchange Fabric detailed documentation:
 * [documentation.gxf.lfenergy.org](https://documentation.gxf.lfenergy.org/)
-
-Grid eXchange Fabric issue tracker:
-* [Grid eXchange Fabric Jira](https://smartsocietyservices.atlassian.net/projects/OC/issues/)


### PR DESCRIPTION
FDP-229 Removed the link to Jira from the GitHub documentation since we migrated the registration of work items to a non-open Jira environment