### PR TITLE
[Documentation] Included the contributors role in Governance page

### DIFF
--- a/Opensourcecommunity/Governance.md
+++ b/Opensourcecommunity/Governance.md
@@ -42,3 +42,8 @@ Current maintainers:
 * Open smart grid platform and smart lighting domain: [Kevin Smeets](https://github.com/kevinsmeets)
 * Smart metering domain: [Sander van der Heijden](https://github.com/smvdheijden)
 * Non-domain specific documentation & configuration: [Robert Tusveld](https://github.com/rtusveld)
+
+###Contributors
+Contributors include anyone in the technical community that contributes code, documentation, or other technical artifacts to the project.
+
+Anyone can become a contributor. There is no expectation of commitment to the project, no specific skill requirements and no selection process. To become a contributor, a community member simply has to perform one or more actions that are beneficial to the project.


### PR DESCRIPTION
Included the contributors role because this role is also mentioned in the GXF charter (https://github.com/lf-energy/foundation/blob/main/project_charters/grid-exchange-frabric-charter.pdf)

Please review and and make changes if you see necessary.

