### PR TITLE
Fixes links to IDE setup documentation in Config repo

### DIFF
--- a/opensourcecommunity/toolsguidelinesci.md
+++ b/opensourcecommunity/toolsguidelinesci.md
@@ -10,7 +10,7 @@ The technology and tools used can be found in the [Technology stack](../architec
 
 * To prevent formatting issues caused by using different IDEs, the formatting style for the code is based on [Google Java Format](https://github.com/google/google-java-format) with some extra additions based on the Eclipse based conventions that were already in use.
 
-  Check the explanation of the [general ideas](https://github.com/OSGP/Config/tree/development/code-format-settings) as well as the instructions how to configure your idea to be able to format according to the conventions \(available for [Eclipse](https://github.com/OSGP/Config/tree/feature/google_java_format/code-format-settings/eclipse) and [IntelliJ](https://github.com/OSGP/Config/tree/feature/google_java_format/code-format-settings/intellij)\).
+  Check the explanation of the [general ideas](https://github.com/OSGP/Config/tree/development/code-format-settings) as well as the instructions how to configure your idea to be able to format according to the conventions \(available for [Eclipse](https://github.com/OSGP/Config/tree/development/code-format-settings/eclipse) and [IntelliJ](https://github.com/OSGP/Config/tree/development/code-format-settings/intellij)\).
 
 * Follow [GitFlow](http://nvie.com/posts/a-successful-git-branching-model/) approach for branching
 * Write behaviour driven tests using [Cucumber and Gherkin](https://cucumber.io), see the [Integration-Tests](https://github.com/OSGP/open-smart-grid-platform/tree/development/integration-tests)


### PR DESCRIPTION
The links to the OSGP Config GitHub repository sections on setting up
Eclipse or IntelliJ for working on the OSGP code base pointed to the
feature branch in which this documentation was last updated.
The Git branch reference is updated to development.
